### PR TITLE
Add dedicated practice page

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,3 @@
-function showScreen(id) {
-  document.querySelectorAll('.screen').forEach(s => s.classList.remove('visible'));
-  document.getElementById(id).classList.add('visible');
-}
-
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
 const drawModeToggle = document.getElementById("drawModeToggle");

--- a/index.html
+++ b/index.html
@@ -10,77 +10,10 @@
   <!-- MENU SCREEN -->
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Memory Shape Drawing Game</h1>
-    <button onclick="showScreen('practiceScreen')">Practice</button>
+    <button onclick="window.location.href='practice.html'">Practice</button>
     <button onclick="window.location.href='scenarios.html'">Scenarios</button>
     <button onclick="window.location.href='about.html'">About</button>
   </div>
 
-  <!-- PRACTICE SCREEN -->
-  <div id="practiceScreen" class="screen practice-screen">
-    <button onclick="showScreen('menuScreen')">← Back to Menu</button>
-    <h2>Memory Shape Drawing Game</h2>
-    <div class="controls">
-      <label>Time (sec):
-        <input type="number" id="timeInput" value="5" min="1" max="60">
-      </label>
-      <label>Sides:
-        <select id="sidesSelect">
-          <option value="1">Point</option>
-          <option value="2">Line Segment</option>
-          <option value="3">3</option>
-          <option value="4" selected>4</option>
-          <option value="5">5</option>
-          <option value="6">6</option>
-          <option value="7">7</option>
-          <option value="8">8</option>
-          <option value="9">9</option>
-          <option value="10">10</option>
-        </select>
-      </label>
-      <label>Size:
-        <select id="sizeSelect">
-          <option value="small">Small</option>
-          <option value="medium" selected>Medium</option>
-          <option value="big">Big</option>
-        </select>
-      </label>
-      <label>Grid:
-        <select id="gridSelect">
-          <option value="0">None</option>
-          <option value="2">2x2</option>
-          <option value="3">3x3</option>
-          <option value="4">4x4</option>
-        </select>
-      </label>
-    </div>
-
-    <div class="switches-group">
-      <label class="switch-label-container">
-        <div class="switch">
-          <input type="checkbox" id="drawModeToggle" checked />
-          <span class="slider"></span>
-        </div>
-        <span class="switch-text" id="drawModeLabel">Point-to-Point</span>
-      </label>
-    </div>
-
-    <div class="checkboxes-group">
-      <label><input type="checkbox" id="giveHighest" /> Highest</label>
-      <label><input type="checkbox" id="giveLowest" /> Lowest</label>
-      <label><input type="checkbox" id="giveLeftmost" /> Left-most</label>
-      <label><input type="checkbox" id="giveRightmost" /> Right-most</label>
-    </div>
-
-    <div class="controls">
-      <button onclick="newShape()">New Shape</button>
-      <button onclick="previousShape()">Previous Shape</button>
-      <button onclick="retryShape()">Retry Shape</button>
-    </div>
-
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
-    <p class="score" id="result"></p>
-  </div>
-
-  <script src="app.js"></script>
 </body>
 </html>

--- a/practice.html
+++ b/practice.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Practice - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="practiceScreen" class="screen practice-screen">
+    <button onclick="window.location.href='index.html'">← Back to Menu</button>
+    <h2>Memory Shape Drawing Game</h2>
+    <div class="controls">
+      <label>Time (sec):
+        <input type="number" id="timeInput" value="5" min="1" max="60">
+      </label>
+      <label>Sides:
+        <select id="sidesSelect">
+          <option value="1">Point</option>
+          <option value="2">Line Segment</option>
+          <option value="3">3</option>
+          <option value="4" selected>4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
+          <option value="10">10</option>
+        </select>
+      </label>
+      <label>Size:
+        <select id="sizeSelect">
+          <option value="small">Small</option>
+          <option value="medium" selected>Medium</option>
+          <option value="big">Big</option>
+        </select>
+      </label>
+      <label>Grid:
+        <select id="gridSelect">
+          <option value="0">None</option>
+          <option value="2">2x2</option>
+          <option value="3">3x3</option>
+          <option value="4">4x4</option>
+        </select>
+      </label>
+    </div>
+
+    <div class="switches-group">
+      <label class="switch-label-container">
+        <div class="switch">
+          <input type="checkbox" id="drawModeToggle" checked />
+          <span class="slider"></span>
+        </div>
+        <span class="switch-text" id="drawModeLabel">Point-to-Point</span>
+      </label>
+    </div>
+
+    <div class="checkboxes-group">
+      <label><input type="checkbox" id="giveHighest" /> Highest</label>
+      <label><input type="checkbox" id="giveLowest" /> Lowest</label>
+      <label><input type="checkbox" id="giveLeftmost" /> Left-most</label>
+      <label><input type="checkbox" id="giveRightmost" /> Right-most</label>
+    </div>
+
+    <div class="controls">
+      <button onclick="newShape()">New Shape</button>
+      <button onclick="previousShape()">Previous Shape</button>
+      <button onclick="retryShape()">Retry Shape</button>
+    </div>
+
+    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <p class="score" id="result"></p>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move practice mode markup out of `index.html`
- create new `practice.html`
- update menu link to point to the new page
- drop unused `showScreen` function

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_688a50da4b288325a96a9db500d6ccca