### PR TITLE
Add customizable scenario builder

### DIFF
--- a/scenario.js
+++ b/scenario.js
@@ -1,0 +1,32 @@
+let scenarioTimer = null;
+
+function startScenario() {
+  clearTimeout(viewTimer);
+  clearTimeout(scenarioTimer);
+
+  const lookTime = Math.max(1000, parseFloat(document.getElementById('timeInput').value) * 1000);
+  const bufferTime = Math.max(0, parseFloat(document.getElementById('bufferInput').value) * 1000);
+  const challengeLength = Math.max(1000, parseFloat(document.getElementById('challengeInput').value) * 1000);
+  const sides = parseInt(document.getElementById('sidesSelect').value);
+
+  lastShape = originalShape.map(p => ({ ...p }));
+  originalShape = generateShape(sides);
+  playerShape = [];
+  drawingEnabled = false;
+  result.textContent = '';
+  clearCanvas();
+  drawGrid();
+  drawShape(originalShape, 'black');
+
+  viewTimer = setTimeout(() => {
+    clearCanvas();
+    drawGrid();
+    drawGivenPoints(originalShape);
+    setTimeout(() => {
+      drawingEnabled = true;
+      scenarioTimer = setTimeout(() => {
+        revealShape();
+      }, challengeLength);
+    }, bufferTime);
+  }, lookTime);
+}

--- a/scenarios.html
+++ b/scenarios.html
@@ -3,14 +3,80 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Scenarios - Memory Shape Drawing Game</title>
+  <title>Scenario Builder - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="menu-screen">
-    <h1>Scenarios</h1>
-    <p>Scenario mode will offer curated challenges. More coming soon!</p>
-    <button onclick="window.location.href='index.html'">Back to Menu</button>
+  <div id="scenarioScreen" class="screen practice-screen">
+    <button onclick="window.location.href='index.html'">← Back to Menu</button>
+    <h2>Create Scenario</h2>
+    <div class="controls">
+      <label>Look Time (sec):
+        <input type="number" id="timeInput" value="5" min="1" max="60">
+      </label>
+      <label>Buffer Time (sec):
+        <input type="number" id="bufferInput" value="1" min="0" max="60">
+      </label>
+      <label>Challenge Length (sec):
+        <input type="number" id="challengeInput" value="10" min="1" max="300">
+      </label>
+      <label>Sides:
+        <select id="sidesSelect">
+          <option value="1">Point</option>
+          <option value="2">Line Segment</option>
+          <option value="3">3</option>
+          <option value="4" selected>4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
+          <option value="10">10</option>
+        </select>
+      </label>
+      <label>Size:
+        <select id="sizeSelect">
+          <option value="small">Small</option>
+          <option value="medium" selected>Medium</option>
+          <option value="big">Big</option>
+        </select>
+      </label>
+      <label>Grid:
+        <select id="gridSelect">
+          <option value="0">None</option>
+          <option value="2">2x2</option>
+          <option value="3">3x3</option>
+          <option value="4">4x4</option>
+        </select>
+      </label>
+    </div>
+
+    <div class="switches-group">
+      <label class="switch-label-container">
+        <div class="switch">
+          <input type="checkbox" id="drawModeToggle" checked />
+          <span class="slider"></span>
+        </div>
+        <span class="switch-text" id="drawModeLabel">Point-to-Point</span>
+      </label>
+    </div>
+
+    <div class="checkboxes-group">
+      <label><input type="checkbox" id="giveHighest" /> Highest</label>
+      <label><input type="checkbox" id="giveLowest" /> Lowest</label>
+      <label><input type="checkbox" id="giveLeftmost" /> Left-most</label>
+      <label><input type="checkbox" id="giveRightmost" /> Right-most</label>
+    </div>
+
+    <div class="controls">
+      <button onclick="startScenario()">Start Challenge</button>
+    </div>
+
+    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <p class="score" id="result"></p>
   </div>
+
+  <script src="app.js"></script>
+  <script src="scenario.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace placeholder scenario page with scenario builder interface
- allow setting look time, buffer time, and challenge duration
- add `scenario.js` script to run a challenge using these parameters

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a5ffa53088325ab1700754186ce58