### PR TITLE
Add scenario saving tool

### DIFF
--- a/scenario.js
+++ b/scenario.js
@@ -1,5 +1,69 @@
 let scenarioTimer = null;
 
+function loadSavedScenarios() {
+  const list = document.getElementById('savedScenarios');
+  if (!list) return;
+  list.innerHTML = '';
+  const data = JSON.parse(localStorage.getItem('scenarios') || '{}');
+  Object.keys(data).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    list.appendChild(opt);
+  });
+  if (list.options.length > 0) {
+    list.selectedIndex = 0;
+    applyScenario();
+  }
+}
+
+function saveScenario() {
+  const name = document.getElementById('scenarioName').value.trim();
+  if (!name) return;
+  const scenarios = JSON.parse(localStorage.getItem('scenarios') || '{}');
+  scenarios[name] = {
+    time: parseFloat(document.getElementById('timeInput').value),
+    buffer: parseFloat(document.getElementById('bufferInput').value),
+    challenge: parseFloat(document.getElementById('challengeInput').value),
+    sides: document.getElementById('sidesSelect').value,
+    size: document.getElementById('sizeSelect').value,
+    grid: document.getElementById('gridSelect').value,
+    drawMode: document.getElementById('drawModeToggle').checked,
+    giveHighest: document.getElementById('giveHighest').checked,
+    giveLowest: document.getElementById('giveLowest').checked,
+    giveLeftmost: document.getElementById('giveLeftmost').checked,
+    giveRightmost: document.getElementById('giveRightmost').checked
+  };
+  localStorage.setItem('scenarios', JSON.stringify(scenarios));
+  loadSavedScenarios();
+  const list = document.getElementById('savedScenarios');
+  if (list) {
+    list.value = name;
+    applyScenario();
+  }
+}
+
+function applyScenario() {
+  const name = document.getElementById('savedScenarios').value;
+  const scenarios = JSON.parse(localStorage.getItem('scenarios') || '{}');
+  const scn = scenarios[name];
+  if (!scn) return;
+  document.getElementById('timeInput').value = scn.time;
+  document.getElementById('bufferInput').value = scn.buffer;
+  document.getElementById('challengeInput').value = scn.challenge;
+  document.getElementById('sidesSelect').value = scn.sides;
+  document.getElementById('sizeSelect').value = scn.size;
+  document.getElementById('gridSelect').value = scn.grid;
+  document.getElementById('drawModeToggle').checked = scn.drawMode;
+  document.getElementById('drawModeLabel').textContent = scn.drawMode ? 'Point-to-Point' : 'Freehand';
+  document.getElementById('giveHighest').checked = scn.giveHighest;
+  document.getElementById('giveLowest').checked = scn.giveLowest;
+  document.getElementById('giveLeftmost').checked = scn.giveLeftmost;
+  document.getElementById('giveRightmost').checked = scn.giveRightmost;
+}
+
+document.addEventListener('DOMContentLoaded', loadSavedScenarios);
+
 function startScenario() {
   clearTimeout(viewTimer);
   clearTimeout(scenarioTimer);

--- a/scenarios.html
+++ b/scenarios.html
@@ -3,13 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Scenario Builder - Memory Shape Drawing Game</title>
+  <title>Scenario Creation Tool - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div id="scenarioScreen" class="screen practice-screen">
     <button onclick="window.location.href='index.html'">← Back to Menu</button>
-    <h2>Create Scenario</h2>
+    <h2>Scenario Creation Tool</h2>
+    <div class="controls">
+      <label>Saved Scenarios:
+        <select id="savedScenarios" onchange="applyScenario()"></select>
+      </label>
+    </div>
+    <div class="controls">
+      <input type="text" id="scenarioName" placeholder="Scenario name">
+      <button onclick="saveScenario()">Save Scenario</button>
+    </div>
     <div class="controls">
       <label>Look Time (sec):
         <input type="number" id="timeInput" value="5" min="1" max="60">
@@ -69,7 +78,7 @@
     </div>
 
     <div class="controls">
-      <button onclick="startScenario()">Start Challenge</button>
+      <button onclick="startScenario()">Start Scenario</button>
     </div>
 
     <canvas id="gameCanvas" width="500" height="500"></canvas>


### PR DESCRIPTION
## Summary
- upgrade scenario builder to **Scenario Creation Tool**
- add dropdown for saved scenarios and ability to save custom scenarios
- store scenarios in browser local storage
- allow starting a scenario from saved settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a62bf2750832593a14f4452b5443d