### PR TITLE
Add grading options and scoring to scenarios

### DIFF
--- a/app.js
+++ b/app.js
@@ -212,6 +212,7 @@ function revealShape() {
     ctx.fillText(i + 1, p.x + 6, p.y - 6);
   });
   result.textContent = "Reveal complete.";
+  document.dispatchEvent(new CustomEvent('shapeRevealed'));
 }
 
 function drawFreehand() {

--- a/scenarios.html
+++ b/scenarios.html
@@ -60,6 +60,27 @@
       </label>
     </div>
 
+    <div class="controls">
+      <label>After Grading:
+        <select id="afterSelect" onchange="toggleThreshold()">
+          <option value="next">Next Shape</option>
+          <option value="repeat">Repeat Until Threshold</option>
+          <option value="end">End Scenario</option>
+        </select>
+      </label>
+      <span id="thresholdWrapper" style="display:none;">
+        <label>Points Needed:
+          <input type="number" id="thresholdPoints" value="1" min="1" style="width:4em;">
+        </label>
+        <label>Grade:
+          <select id="thresholdGrade">
+            <option value="green">Green</option>
+            <option value="yellow">Yellow</option>
+          </select>
+        </label>
+      </span>
+    </div>
+
     <div class="switches-group">
       <label class="switch-label-container">
         <div class="switch">


### PR DESCRIPTION
## Summary
- extend scenario creation page with options for what happens after grading
- store new fields with scenarios
- implement scoring logic for green/yellow/red points and count shapes with no red
- let scenarios repeat a shape until a grade threshold is met
- dispatch a `shapeRevealed` event from `revealShape`

## Testing
- `node --check scenario.js`
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_688a67458dd08325bbdae362835833ea