### PR TITLE
Add scenario selection and play flow

### DIFF
--- a/saved_scenarios.html
+++ b/saved_scenarios.html
@@ -7,102 +7,38 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="scenarioScreen" class="screen practice-screen">
+  <div class="menu-screen">
     <button onclick="window.location.href='index.html'">← Back to Menu</button>
     <h2>Saved Scenarios</h2>
     <div class="controls">
-      <label>Saved Scenarios:
-        <select id="savedScenarios" onchange="applyScenario()"></select>
+      <label>Choose Scenario:
+        <select id="scenarioList"></select>
       </label>
     </div>
     <div class="controls">
-      <label>Look Time (sec):
-        <input type="number" id="timeInput" value="5" min="1" max="60">
-      </label>
-      <label>Buffer Time (sec):
-        <input type="number" id="bufferInput" value="1" min="0" max="60">
-      </label>
-      <label>Challenge Length (sec):
-        <input type="number" id="challengeInput" value="10" min="1" max="300">
-      </label>
-      <label>Sides:
-        <select id="sidesSelect">
-          <option value="1">Point</option>
-          <option value="2">Line Segment</option>
-          <option value="3">3</option>
-          <option value="4" selected>4</option>
-          <option value="5">5</option>
-          <option value="6">6</option>
-          <option value="7">7</option>
-          <option value="8">8</option>
-          <option value="9">9</option>
-          <option value="10">10</option>
-        </select>
-      </label>
-      <label>Size:
-        <select id="sizeSelect">
-          <option value="small">Small</option>
-          <option value="medium" selected>Medium</option>
-          <option value="big">Big</option>
-        </select>
-      </label>
-      <label>Grid:
-        <select id="gridSelect">
-          <option value="0">None</option>
-          <option value="2">2x2</option>
-          <option value="3">3x3</option>
-          <option value="4">4x4</option>
-        </select>
-      </label>
+      <button id="playBtn">Play Scenario</button>
     </div>
-
-    <div class="controls">
-      <label>After Grading:
-        <select id="afterSelect" onchange="toggleThreshold()">
-          <option value="next">Next Shape</option>
-          <option value="repeat">Repeat Until Threshold</option>
-          <option value="end">End Scenario</option>
-        </select>
-      </label>
-      <span id="thresholdWrapper" style="display:none;">
-        <label>Points Needed:
-          <input type="number" id="thresholdPoints" value="1" min="1" style="width:4em;">
-        </label>
-        <label>Grade:
-          <select id="thresholdGrade">
-            <option value="green">Green</option>
-            <option value="yellow">Yellow</option>
-          </select>
-        </label>
-      </span>
-    </div>
-
-    <div class="switches-group">
-      <label class="switch-label-container">
-        <div class="switch">
-          <input type="checkbox" id="drawModeToggle" checked />
-          <span class="slider"></span>
-        </div>
-        <span class="switch-text" id="drawModeLabel">Point-to-Point</span>
-      </label>
-    </div>
-
-    <div class="checkboxes-group">
-      <label><input type="checkbox" id="giveHighest" /> Highest</label>
-      <label><input type="checkbox" id="giveLowest" /> Lowest</label>
-      <label><input type="checkbox" id="giveLeftmost" /> Left-most</label>
-      <label><input type="checkbox" id="giveRightmost" /> Right-most</label>
-    </div>
-
-    <div class="controls">
-      <button onclick="startScenario()">Start Scenario</button>
-    </div>
-
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
-    <p class="score" id="result"></p>
   </div>
-
-  <script src="app.js"></script>
-  <script src="scenario.js"></script>
+  <script>
+    function loadScenarioList() {
+      const list = document.getElementById('scenarioList');
+      const data = JSON.parse(localStorage.getItem('scenarios') || '{}');
+      list.innerHTML = '';
+      Object.keys(data).forEach(name => {
+        const opt = document.createElement('option');
+        opt.value = name;
+        opt.textContent = name;
+        list.appendChild(opt);
+      });
+    }
+    function playSelectedScenario() {
+      const name = document.getElementById('scenarioList').value;
+      if (name) {
+        window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);
+      }
+    }
+    document.getElementById('playBtn').addEventListener('click', playSelectedScenario);
+    document.addEventListener('DOMContentLoaded', loadScenarioList);
+  </script>
 </body>
 </html>

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Play Scenario - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button onclick="window.location.href='saved_scenarios.html'">← Back</button>
+    <h2 id="scenarioTitle">Scenario</h2>
+    <button id="startBtn">Start Challenge</button>
+    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <p class="score" id="result"></p>
+    <div style="display:none">
+      <input type="number" id="timeInput" value="5">
+      <input type="number" id="bufferInput" value="1">
+      <input type="number" id="challengeInput" value="10">
+      <select id="sidesSelect">
+        <option value="1">Point</option>
+        <option value="2">Line Segment</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+        <option value="6">6</option>
+        <option value="7">7</option>
+        <option value="8">8</option>
+        <option value="9">9</option>
+        <option value="10">10</option>
+      </select>
+      <select id="sizeSelect">
+        <option value="small">Small</option>
+        <option value="medium">Medium</option>
+        <option value="big">Big</option>
+      </select>
+      <select id="gridSelect">
+        <option value="0">None</option>
+        <option value="2">2x2</option>
+        <option value="3">3x3</option>
+        <option value="4">4x4</option>
+      </select>
+      <input type="checkbox" id="drawModeToggle" checked />
+      <span id="drawModeLabel"></span>
+      <input type="checkbox" id="giveHighest">
+      <input type="checkbox" id="giveLowest">
+      <input type="checkbox" id="giveLeftmost">
+      <input type="checkbox" id="giveRightmost">
+      <select id="afterSelect">
+        <option value="next">Next Shape</option>
+        <option value="repeat">Repeat Until Threshold</option>
+        <option value="end">End Scenario</option>
+      </select>
+      <input type="number" id="thresholdPoints" value="1">
+      <select id="thresholdGrade">
+        <option value="green">Green</option>
+        <option value="yellow">Yellow</option>
+      </select>
+      <span id="thresholdWrapper"></span>
+    </div>
+  </div>
+  <script src="app.js"></script>
+  <script src="scenario.js"></script>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const name = params.get('name') || '';
+    document.getElementById('scenarioTitle').textContent = name || 'Scenario';
+    const scenarios = JSON.parse(localStorage.getItem('scenarios') || '{}');
+    const scn = scenarios[name];
+    const startBtn = document.getElementById('startBtn');
+    if (!scn) {
+      document.getElementById('result').textContent = 'Scenario not found.';
+      startBtn.disabled = true;
+    } else {
+      document.getElementById('timeInput').value = scn.time;
+      document.getElementById('bufferInput').value = scn.buffer;
+      document.getElementById('challengeInput').value = scn.challenge;
+      document.getElementById('sidesSelect').value = scn.sides;
+      document.getElementById('sizeSelect').value = scn.size;
+      document.getElementById('gridSelect').value = scn.grid;
+      document.getElementById('drawModeToggle').checked = scn.drawMode;
+      document.getElementById('drawModeLabel').textContent = scn.drawMode ? 'Point-to-Point' : 'Freehand';
+      document.getElementById('giveHighest').checked = scn.giveHighest;
+      document.getElementById('giveLowest').checked = scn.giveLowest;
+      document.getElementById('giveLeftmost').checked = scn.giveLeftmost;
+      document.getElementById('giveRightmost').checked = scn.giveRightmost;
+      document.getElementById('afterSelect').value = scn.afterAction || 'end';
+      document.getElementById('thresholdPoints').value = scn.thresholdPoints || 1;
+      document.getElementById('thresholdGrade').value = scn.thresholdGrade || 'green';
+      toggleThreshold();
+    }
+    startBtn.addEventListener('click', () => {
+      result.textContent = '';
+      startScenario();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- simplify `saved_scenarios.html` into a list of created scenarios
- add new `scenario_play.html` which loads a scenario and only shows a canvas and start button

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688a6df061048325aab49c04697f2a3a