### PR TITLE
Add selection flow for editing scenarios

### DIFF
--- a/scenario.js
+++ b/scenario.js
@@ -45,18 +45,28 @@ function onShapeRevealed() {
 
 document.addEventListener('shapeRevealed', onShapeRevealed);
 
-function loadSavedScenarios() {
-  const list = document.getElementById('savedScenarios');
-  if (!list) return;
-  list.innerHTML = '';
-  const data = JSON.parse(localStorage.getItem('scenarios') || '{}');
+function getSavedScenarios() {
+  return JSON.parse(localStorage.getItem('scenarios') || '{}');
+}
+
+function populateScenarioSelect(id) {
+  const select = document.getElementById(id);
+  if (!select) return;
+  select.innerHTML = '';
+  const data = getSavedScenarios();
   Object.keys(data).forEach(name => {
     const opt = document.createElement('option');
     opt.value = name;
     opt.textContent = name;
-    list.appendChild(opt);
+    select.appendChild(opt);
   });
-  if (list.options.length > 0) {
+}
+
+function loadSavedScenarios() {
+  populateScenarioSelect('savedScenarios');
+  populateScenarioSelect('editScenarioSelect');
+  const list = document.getElementById('savedScenarios');
+  if (list && list.options.length > 0) {
     list.selectedIndex = 0;
     applyScenario();
   }
@@ -114,9 +124,33 @@ function applyScenario() {
   toggleThreshold();
 }
 
+function showScreen(id) {
+  document.querySelectorAll('.screen').forEach(el => el.classList.remove('visible'));
+  const el = document.getElementById(id);
+  if (el) el.classList.add('visible');
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  loadSavedScenarios();
+  populateScenarioSelect('savedScenarios');
+  populateScenarioSelect('editScenarioSelect');
   toggleThreshold();
+
+  const newBtn = document.getElementById('newScenarioBtn');
+  const editBtn = document.getElementById('editScenarioBtn');
+  const loadBtn = document.getElementById('loadScenarioBtn');
+  const backBtn = document.getElementById('selectBackBtn');
+
+  if (newBtn) newBtn.addEventListener('click', () => showScreen('scenarioScreen'));
+  if (editBtn) editBtn.addEventListener('click', () => showScreen('selectScreen'));
+  if (backBtn) backBtn.addEventListener('click', () => showScreen('modeScreen'));
+  if (loadBtn) loadBtn.addEventListener('click', () => {
+    const sel = document.getElementById('editScenarioSelect');
+    if (!sel || !sel.value) return;
+    const list = document.getElementById('savedScenarios');
+    if (list) list.value = sel.value;
+    applyScenario();
+    showScreen('scenarioScreen');
+  });
 });
 
 function startScenario(repeat = false) {

--- a/scenario_creator.html
+++ b/scenario_creator.html
@@ -6,15 +6,33 @@
   <title>Scenario Creator - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <div id="scenarioScreen" class="screen practice-screen">
-    <button onclick="window.location.href='index.html'">← Back to Menu</button>
-    <h2>Scenario Creator</h2>
-    <div class="controls">
-      <label>Saved Scenarios:
-        <select id="savedScenarios" onchange="applyScenario()"></select>
-      </label>
+  <body>
+    <div id="modeScreen" class="screen practice-screen visible">
+      <button onclick="window.location.href='index.html'">← Back to Menu</button>
+      <h2>Scenario Creator</h2>
+      <button id="newScenarioBtn">Create New Scenario</button>
+      <button id="editScenarioBtn">Edit Saved Scenario</button>
     </div>
+
+    <div id="selectScreen" class="screen practice-screen">
+      <button id="selectBackBtn">← Back</button>
+      <h2>Select Scenario to Edit</h2>
+      <div class="controls">
+        <label>Saved Scenarios:
+          <select id="editScenarioSelect"></select>
+        </label>
+        <button id="loadScenarioBtn">Edit</button>
+      </div>
+    </div>
+
+    <div id="scenarioScreen" class="screen practice-screen">
+      <button onclick="window.location.href='index.html'">← Back to Menu</button>
+      <h2>Scenario Creator</h2>
+      <div class="controls">
+        <label>Saved Scenarios:
+          <select id="savedScenarios" onchange="applyScenario()"></select>
+        </label>
+      </div>
     <div class="controls">
       <input type="text" id="scenarioName" placeholder="Scenario name">
       <button onclick="saveScenario()">Save Scenario</button>


### PR DESCRIPTION
## Summary
- add intro screen with new/edit options in `scenario_creator.html`
- implement dropdown selection flow for editing saved scenarios
- update scenario logic to populate dropdowns and manage screen switching

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check scenario.js`

------
https://chatgpt.com/codex/tasks/task_e_688a6eb0ca2483259c03ad6d9e672b3d