### PR TITLE
Show placed points after grading in practice mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -207,6 +207,7 @@ function revealShape() {
     let color = "red";
     if (closest.d <= 5) color = "green";
     else if (closest.d <= 10) color = "orange";
+    drawDot(p, color);
     ctx.fillStyle = color;
     ctx.font = "16px sans-serif";
     ctx.fillText(i + 1, p.x + 6, p.y - 6);


### PR DESCRIPTION
## Summary
- Draw the player's placed point when the shape is revealed in practice mode
- Keep numbering and color grading intact, but now points are visible

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952f01c79883258087f5c11864750b