### PR TITLE
Add angle memorization challenge under scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ When you are done drawing, the original shape is revealed so you can compare.
 ## Dependencies
 
 There are no external dependencies aside from a modern web browser that supports HTML5 and JavaScript.
-=======
-This project is a simple browser game where you attempt to reproduce shapes from memory. Choose the practice mode or try a set of predefined scenarios and see how close your drawing is to the original.
 
 ## License
 

--- a/angles.html
+++ b/angles.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Angle Memorization Challenge</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button onclick="window.location.href='scenarios.html'">← Back to Scenarios</button>
+    <h2>Angle Memorization Challenge</h2>
+    <canvas id="angleCanvas" width="500" height="500"></canvas>
+    <div id="angleOptions" class="angle-options"></div>
+    <p class="score" id="angleResult"></p>
+  </div>
+  <script src="angles.js"></script>
+</body>
+</html>

--- a/angles.js
+++ b/angles.js
@@ -1,0 +1,92 @@
+const canvas = document.getElementById('angleCanvas');
+const ctx = canvas.getContext('2d');
+const optionsContainer = document.getElementById('angleOptions');
+const result = document.getElementById('angleResult');
+
+let availableAngles = [];
+let currentAngle = null;
+let correctCount = 0;
+let totalSelected = 0;
+
+function initOptions() {
+  for (let a = 5; a <= 180; a += 5) {
+    availableAngles.push(a);
+    const label = document.createElement('label');
+    label.className = 'angle-option';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.dataset.angle = a;
+
+    const box = document.createElement('span');
+    box.className = 'box';
+
+    const text = document.createTextNode(`${a}\u00B0`);
+
+    label.appendChild(input);
+    label.appendChild(box);
+    label.appendChild(text);
+    optionsContainer.appendChild(label);
+
+    input.addEventListener('click', onSelect);
+  }
+}
+
+function drawAngle(angle) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+  const length = 200;
+  const rotation = Math.random() * Math.PI * 2;
+
+  const x1 = centerX + length * Math.cos(rotation);
+  const y1 = centerY + length * Math.sin(rotation);
+  const x2 = centerX + length * Math.cos(rotation + angle * Math.PI / 180);
+  const y2 = centerY + length * Math.sin(rotation + angle * Math.PI / 180);
+
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = 'black';
+
+  ctx.beginPath();
+  ctx.moveTo(centerX, centerY);
+  ctx.lineTo(x1, y1);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(centerX, centerY);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+}
+
+function onSelect(e) {
+  const selected = parseInt(e.target.dataset.angle);
+  e.target.disabled = true;
+  const label = e.target.parentElement;
+  if (selected === currentAngle) {
+    label.classList.add('correct');
+    correctCount++;
+  } else {
+    label.classList.add('incorrect');
+  }
+  totalSelected++;
+  availableAngles = availableAngles.filter(a => a !== selected);
+
+  if (totalSelected === 36) {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    result.textContent = `You got ${correctCount} out of 36 correct.`;
+  } else {
+    nextAngle();
+  }
+}
+
+function nextAngle() {
+  if (!availableAngles.length) return;
+  const idx = Math.floor(Math.random() * availableAngles.length);
+  currentAngle = availableAngles[idx];
+  drawAngle(currentAngle);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initOptions();
+  nextAngle();
+});

--- a/scenarios.html
+++ b/scenarios.html
@@ -30,11 +30,19 @@
         opt.textContent = name;
         list.appendChild(opt);
       });
+      const angleOpt = document.createElement('option');
+      angleOpt.value = 'Angle Challenge';
+      angleOpt.textContent = 'Angle Challenge';
+      list.appendChild(angleOpt);
     }
     function playSelectedScenario() {
       const name = document.getElementById('scenarioList').value;
       if (name) {
-        window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);
+        if (name === 'Angle Challenge') {
+          window.location.href = 'angles.html';
+        } else {
+          window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);
+        }
       }
     }
     document.getElementById('playBtn').addEventListener('click', playSelectedScenario);

--- a/style.css
+++ b/style.css
@@ -103,3 +103,55 @@ button {
   cursor: pointer;
 }
 h2, h1 { margin: 10px 0; }
+
+/* Angle memorization styles */
+.angle-options {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  margin: 10px 0;
+}
+
+.angle-option {
+  position: relative;
+  padding-left: 20px;
+  font-size: 14px;
+}
+
+.angle-option input {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  opacity: 0;
+}
+
+.angle-option .box {
+  position: absolute;
+  left: 0;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border: 1px solid #333;
+  box-sizing: border-box;
+}
+
+.angle-option.correct .box::after {
+  content: '\2713';
+  color: green;
+  position: absolute;
+  left: 2px;
+  top: -3px;
+  font-size: 18px;
+}
+
+.angle-option.incorrect .box::after {
+  content: '\2717';
+  color: red;
+  position: absolute;
+  left: 2px;
+  top: -3px;
+  font-size: 18px;
+}


### PR DESCRIPTION
## Summary
- add Angle Challenge to Scenarios menu with redirect
- include standalone Angle Memorization Challenge page with random angles and checkbox answers
- style challenge options for clear right/wrong feedback and remove README mention

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689766e800548325aaf56496ed38e886