### PR TITLE
Fix scenario selection dropdown

### DIFF
--- a/scenarios.html
+++ b/scenarios.html
@@ -37,14 +37,10 @@
     }
     function playSelectedScenario() {
       const name = document.getElementById('scenarioList').value;
-      if (name) {
-        if (name === 'Angle Challenge') {
-          window.location.href = 'angles.html';
-        } else {
-          window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);
-        }
       if (!name) return;
-      if (name === 'Point Warmup') {
+      if (name === 'Angle Challenge') {
+        window.location.href = 'angles.html';
+      } else if (name === 'Point Warmup') {
         window.location.href = 'point_warmup.html';
       } else {
         window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);


### PR DESCRIPTION
## Summary
- Fix choose scenario dropdown by simplifying `playSelectedScenario`
- Properly handle Angle Challenge, Point Warmup, and other scenarios

## Testing
- `node --check /tmp/playSelectedScenario.js`


------
https://chatgpt.com/codex/tasks/task_e_68977070ac248325afefa6bdfdb0cad3