### PR TITLE
Hide warmup and drill scenarios

### DIFF
--- a/scenarios.js
+++ b/scenarios.js
@@ -41,5 +41,7 @@ function getScenario(name) {
 }
 
 function getScenarioNames() {
-  return Object.keys(builtInScenarios);
+  return Object.keys(builtInScenarios).filter(
+    name => name !== "Triangle Warmup" && name !== "Square Drill"
+  );
 }


### PR DESCRIPTION
## Summary
- Exclude "Triangle Warmup" and "Square Drill" from the scenario selection dropdown by filtering them out in `getScenarioNames`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897737e51188325a3801af475f46b09