### PR TITLE
Include saved scenarios in scenario menu

### DIFF
--- a/scenarios.js
+++ b/scenarios.js
@@ -39,12 +39,20 @@ const builtInScenarios = {
   }
 };
 
+function getSavedScenarios() {
+  return JSON.parse(localStorage.getItem('scenarios') || '{}');
+}
+
 function getScenario(name) {
-  return builtInScenarios[name];
+  return builtInScenarios[name] || getSavedScenarios()[name];
 }
 
 function getScenarioNames() {
-  return Object.keys(builtInScenarios).filter(
-    name => name !== "Triangle Warmup" && name !== "Square Drill"
-  );
+  const saved = getSavedScenarios();
+  return [
+    ...Object.keys(builtInScenarios).filter(
+      name => name !== "Triangle Warmup" && name !== "Square Drill"
+    ),
+    ...Object.keys(saved)
+  ];
 }


### PR DESCRIPTION
## Summary
- show custom saved scenarios alongside built-ins
- allow playing saved scenarios by resolving them from local storage

## Testing
- `node --check scenarios.js`

------
https://chatgpt.com/codex/tasks/task_e_68977f50a7a88325b9d65aa0a018d02d