### PR TITLE
Add options for Point Warmup and Inch Drill scenarios

### DIFF
--- a/scenarios.html
+++ b/scenarios.html
@@ -34,6 +34,14 @@
       angleOpt.value = 'Angle Challenge';
       angleOpt.textContent = 'Angle Challenge';
       list.appendChild(angleOpt);
+      const pointOpt = document.createElement('option');
+      pointOpt.value = 'Point Warmup';
+      pointOpt.textContent = 'Point Warmup';
+      list.appendChild(pointOpt);
+      const inchOpt = document.createElement('option');
+      inchOpt.value = 'Inch Drill';
+      inchOpt.textContent = 'Inch Drill';
+      list.appendChild(inchOpt);
     }
     function playSelectedScenario() {
       const name = document.getElementById('scenarioList').value;


### PR DESCRIPTION
## Summary
- Append "Point Warmup" and "Inch Drill" options to the scenario dropdown so they can be launched from the scenarios page.
- `playSelectedScenario` already routes these options to the appropriate pages.

## Testing
- `npm test` *(fails: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68978b4cea188325a550ba108d401cda