### PR TITLE
Add dynamic PPI calibration to inch drill

### DIFF
--- a/inch_warmup.html
+++ b/inch_warmup.html
@@ -11,6 +11,7 @@
     <button onclick="window.location.href='scenarios.html'">← Back</button>
     <h2>Inch Drill</h2>
     <button id="startBtn">Start</button>
+    <label>PPI: <input id="ppiInput" type="number" step="0.1" /></label>
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -2,6 +2,7 @@ const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 const startBtn = document.getElementById('startBtn');
 const result = document.getElementById('result');
+const ppiInput = document.getElementById('ppiInput');
 
 let playing = false;
 let drawing = false;
@@ -12,7 +13,23 @@ let stats = null;
 let currentArrow = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-const PPI = window.devicePixelRatio * 96;
+
+const tmp = document.createElement('div');
+tmp.style.width = '1in';
+tmp.style.position = 'absolute';
+tmp.style.visibility = 'hidden';
+document.body.appendChild(tmp);
+let PPI = tmp.offsetWidth;   // true pixels per inch
+document.body.removeChild(tmp);
+
+ppiInput.value = PPI.toFixed(1);
+ppiInput.addEventListener('input', () => {
+  const val = parseFloat(ppiInput.value);
+  if (!isNaN(val) && val > 0) {
+    PPI = val;
+    if (playing) drawArrow();
+  }
+});
 
 function getCanvasPos(e) {
   const rect = canvas.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- compute screen PPI at runtime using a hidden 1in element
- allow players to tweak PPI with a numeric input for manual calibration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689797b71d4c8325bfb7a221a8e1b435