### PR TITLE
Limit scenarios to core drills

### DIFF
--- a/scenarios.html
+++ b/scenarios.html
@@ -30,18 +30,6 @@
         opt.textContent = name;
         list.appendChild(opt);
       });
-      const angleOpt = document.createElement('option');
-      angleOpt.value = 'Angle Challenge';
-      angleOpt.textContent = 'Angle Challenge';
-      list.appendChild(angleOpt);
-      const pointOpt = document.createElement('option');
-      pointOpt.value = 'Point Warmup';
-      pointOpt.textContent = 'Point Warmup';
-      list.appendChild(pointOpt);
-      const inchOpt = document.createElement('option');
-      inchOpt.value = 'Inch Drill';
-      inchOpt.textContent = 'Inch Drill';
-      list.appendChild(inchOpt);
     }
     function playSelectedScenario() {
       const name = document.getElementById('scenarioList').value;

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,42 +1,7 @@
 const builtInScenarios = {
-  "Triangle Warmup": {
-    time: 5,
-    buffer: 1,
-    challenge: 10,
-    sides: 3,
-    size: "medium",
-    grid: "0",
-    drawMode: true,
-    giveHighest: false,
-    giveLowest: false,
-    giveLeftmost: false,
-    giveRightmost: false,
-    afterAction: "end",
-    thresholdPoints: 1,
-    thresholdGrade: "green"
-  },
-  "Square Drill": {
-    time: 5,
-    buffer: 0,
-    challenge: 10,
-    sides: 4,
-    size: "medium",
-    grid: "0",
-    drawMode: true,
-    giveHighest: false,
-    giveLowest: false,
-    giveLeftmost: false,
-    giveRightmost: false,
-    afterAction: "end",
-    thresholdPoints: 1,
-    thresholdGrade: "green"
-  },
-  "Point Warmup": {
-    special: true
-  },
-  "Inch Drill": {
-    special: true
-  }
+  "Point Warmup": { special: true },
+  "Angle Challenge": { special: true },
+  "Inch Drill": { special: true }
 };
 
 function getSavedScenarios() {
@@ -48,11 +13,5 @@ function getScenario(name) {
 }
 
 function getScenarioNames() {
-  const saved = getSavedScenarios();
-  return [
-    ...Object.keys(builtInScenarios).filter(
-      name => name !== "Triangle Warmup" && name !== "Square Drill"
-    ),
-    ...Object.keys(saved)
-  ];
+  return Object.keys(builtInScenarios);
 }


### PR DESCRIPTION
## Summary
- Trim built-in scenario list to only include Point Warmup, Angle Challenge, and Inch Drill.
- Update scenarios menu to populate from the reduced list without duplicates.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689799b25b5883258ce1e078aca9e838