### PR TITLE
Ensure Point Warmup shows in scenario dropdown

### DIFF
--- a/scenarios.js
+++ b/scenarios.js
@@ -13,5 +13,5 @@ function getScenario(name) {
 }
 
 function getScenarioNames() {
-  return Object.keys(builtInScenarios);
+  return [...Object.keys(builtInScenarios), ...Object.keys(getSavedScenarios())];
 }


### PR DESCRIPTION
## Summary
- Include saved scenarios alongside built-ins when populating scenario names

## Testing
- `node -e "global.localStorage={getItem:()=>null}; const { readFileSync }=require('fs'); const vm=require('vm'); const code=readFileSync('scenarios.js','utf8'); vm.runInThisContext(code); console.log(getScenarioNames());"`


------
https://chatgpt.com/codex/tasks/task_e_68979f657d088325868f9270bb2864f8