### PR TITLE
Fix PPI scaling in inch drill scenario

### DIFF
--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -14,19 +14,21 @@ let currentArrow = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
+const DPR = window.devicePixelRatio || 1;
 const tmp = document.createElement('div');
 tmp.style.width = '1in';
 tmp.style.position = 'absolute';
 tmp.style.visibility = 'hidden';
 document.body.appendChild(tmp);
-let PPI = tmp.offsetWidth;   // true pixels per inch
+let PPI = tmp.offsetWidth;   // CSS pixels per inch
 document.body.removeChild(tmp);
 
-ppiInput.value = PPI.toFixed(1);
+// Show the approximate physical PPI to the user but store CSS pixels per inch internally.
+ppiInput.value = (PPI * DPR).toFixed(1);
 ppiInput.addEventListener('input', () => {
   const val = parseFloat(ppiInput.value);
   if (!isNaN(val) && val > 0) {
-    PPI = val;
+    PPI = val / DPR; // convert physical PPI to CSS pixels per inch
     if (playing) drawArrow();
   }
 });


### PR DESCRIPTION
## Summary
- Correct inch drill scaling by factoring in `devicePixelRatio`
- Show physical PPI in input but convert to CSS pixels for accurate lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ada260c8325b67d86bc17bb8bcf