### PR TITLE
refactor: move inline events to scripts

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,7 +10,8 @@
   <div class="menu-screen">
     <h1>About</h1>
     <p>This project is a simple memory drawing game created by Sawyer Wall.</p>
-    <button onclick="window.location.href='index.html'">Back to Menu</button>
+    <button id="menuBtn">Back to Menu</button>
   </div>
+  <script src="about.js"></script>
 </body>
 </html>

--- a/about.js
+++ b/about.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('menuBtn')?.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
+});

--- a/angles.html
+++ b/angles.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button onclick="window.location.href='scenarios.html'">← Back to Scenarios</button>
+    <button id="backBtn">← Back to Scenarios</button>
     <h2>Angle Challenge Drill</h2>
     <button id="startBtn">Start</button>
     <canvas id="angleCanvas" width="500" height="500"></canvas>

--- a/angles.js
+++ b/angles.js
@@ -110,6 +110,9 @@ function nextAngle() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('backBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
   createOptions();
   if (step !== 5) {
     const title = `Angle Challenge Drill (${step}\u00B0 increments)`;

--- a/app.js
+++ b/app.js
@@ -1,9 +1,4 @@
-const canvas = document.getElementById("gameCanvas");
-const ctx = canvas.getContext("2d");
-const drawModeToggle = document.getElementById("drawModeToggle");
-const drawModeLabel = document.getElementById("drawModeLabel");
-const gridSelect = document.getElementById("gridSelect");
-const result = document.getElementById("result");
+let canvas, ctx, drawModeToggle, drawModeLabel, gridSelect, result;
 
 let originalShape = [];
 let playerShape = [];
@@ -12,37 +7,56 @@ let drawingEnabled = false;
 let lastShape = [];
 let viewTimer = null;
 
-drawModeToggle.addEventListener("change", () => {
-  drawModeLabel.textContent = drawModeToggle.checked ? "Point-to-Point" : "Freehand";
-});
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  drawModeToggle = document.getElementById('drawModeToggle');
+  drawModeLabel = document.getElementById('drawModeLabel');
+  gridSelect = document.getElementById('gridSelect');
+  result = document.getElementById('result');
 
-canvas.addEventListener("pointerdown", (e) => {
-  if (!drawingEnabled) return;
-  const pos = getCanvasPos(e);
-  if (drawModeToggle.checked) {
-    playerShape.push(pos);
-    drawDots();
-    if (playerShape.length === originalShape.length) {
-      setTimeout(revealShape, 300);
-    }
-  } else {
-    isDrawing = true;
-    playerShape = [pos];
-    drawFreehand();
+  if (drawModeToggle && drawModeLabel) {
+    drawModeToggle.addEventListener('change', () => {
+      drawModeLabel.textContent = drawModeToggle.checked ? 'Point-to-Point' : 'Freehand';
+    });
   }
-});
 
-canvas.addEventListener("pointermove", (e) => {
-  if (!drawingEnabled || drawModeToggle.checked || !isDrawing) return;
-  const pos = getCanvasPos(e);
-  playerShape.push(pos);
-  drawFreehand();
-});
+  canvas.addEventListener('pointerdown', (e) => {
+    if (!drawingEnabled) return;
+    const pos = getCanvasPos(e);
+    if (drawModeToggle?.checked) {
+      playerShape.push(pos);
+      drawDots();
+      if (playerShape.length === originalShape.length) {
+        setTimeout(revealShape, 300);
+      }
+    } else {
+      isDrawing = true;
+      playerShape = [pos];
+      drawFreehand();
+    }
+  });
 
-canvas.addEventListener("pointerup", () => {
-  if (!drawingEnabled || drawModeToggle.checked) return;
-  isDrawing = false;
-  revealShape();
+  canvas.addEventListener('pointermove', (e) => {
+    if (!drawingEnabled || drawModeToggle?.checked || !isDrawing) return;
+    const pos = getCanvasPos(e);
+    playerShape.push(pos);
+    drawFreehand();
+  });
+
+  canvas.addEventListener('pointerup', () => {
+    if (!drawingEnabled || drawModeToggle?.checked) return;
+    isDrawing = false;
+    revealShape();
+  });
+
+  document.getElementById('newShapeBtn')?.addEventListener('click', newShape);
+  document.getElementById('previousShapeBtn')?.addEventListener('click', previousShape);
+  document.getElementById('retryShapeBtn')?.addEventListener('click', retryShape);
+  document.getElementById('menuBtn')?.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
 });
 
 function getCanvasPos(e) {

--- a/inch_warmup.html
+++ b/inch_warmup.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button onclick="window.location.href='scenarios.html'">← Back</button>
+    <button id="backBtn">← Back</button>
     <h2>Inch Drill</h2>
     <button id="startBtn">Start</button>
     <label>PPI: <input id="ppiInput" type="number" step="0.1" /></label>

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -1,8 +1,4 @@
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
-const startBtn = document.getElementById('startBtn');
-const result = document.getElementById('result');
-const ppiInput = document.getElementById('ppiInput');
+let canvas, ctx, startBtn, result, ppiInput;
 
 let playing = false;
 let drawing = false;
@@ -24,13 +20,30 @@ let PPI = tmp.offsetWidth;   // CSS pixels per inch
 document.body.removeChild(tmp);
 
 // Show the approximate physical PPI to the user but store CSS pixels per inch internally.
-ppiInput.value = (PPI * DPR).toFixed(1);
-ppiInput.addEventListener('input', () => {
-  const val = parseFloat(ppiInput.value);
-  if (!isNaN(val) && val > 0) {
-    PPI = val / DPR; // convert physical PPI to CSS pixels per inch
-    if (playing) drawArrow();
-  }
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+  ppiInput = document.getElementById('ppiInput');
+
+  ppiInput.value = (PPI * DPR).toFixed(1);
+  ppiInput.addEventListener('input', () => {
+    const val = parseFloat(ppiInput.value);
+    if (!isNaN(val) && val > 0) {
+      PPI = val / DPR; // convert physical PPI to CSS pixels per inch
+      if (playing) drawArrow();
+    }
+  });
+
+  canvas.addEventListener('pointerdown', pointerDown);
+  canvas.addEventListener('pointermove', pointerMove);
+  canvas.addEventListener('pointerup', pointerUp);
+  startBtn.addEventListener('click', startGame);
+  document.getElementById('backBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
 });
 
 function getCanvasPos(e) {
@@ -178,7 +191,3 @@ function endGame() {
   startBtn.disabled = false;
 }
 
-canvas.addEventListener('pointerdown', pointerDown);
-canvas.addEventListener('pointermove', pointerMove);
-canvas.addEventListener('pointerup', pointerUp);
-startBtn.addEventListener('click', startGame);

--- a/index.html
+++ b/index.html
@@ -10,10 +10,10 @@
   <!-- MENU SCREEN -->
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Memory Shape Drawing Game</h1>
-    <button onclick="window.location.href='practice.html'">Practice</button>
-    <button onclick="window.location.href='scenarios.html'">Scenarios</button>
-    <button onclick="window.location.href='about.html'">About</button>
+    <button id="practiceBtn">Practice</button>
+    <button id="scenariosBtn">Scenarios</button>
+    <button id="aboutBtn">About</button>
   </div>
-
+  <script src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('practiceBtn')?.addEventListener('click', () => {
+    window.location.href = 'practice.html';
+  });
+  document.getElementById('scenariosBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
+  document.getElementById('aboutBtn')?.addEventListener('click', () => {
+    window.location.href = 'about.html';
+  });
+});

--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button onclick="window.location.href='scenarios.html'">← Back</button>
+    <button id="backBtn">← Back</button>
     <h2>Point Drill 0.1 sec Look</h2>
     <button id="startBtn">Start</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -1,7 +1,4 @@
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
-const startBtn = document.getElementById('startBtn');
-const result = document.getElementById('result');
+let canvas, ctx, startBtn, result;
 
 let playing = false;
 let awaitingClick = false;
@@ -127,5 +124,16 @@ function endGame() {
   startBtn.disabled = false;
 }
 
-canvas.addEventListener('pointerdown', pointerDown);
-startBtn.addEventListener('click', startGame);
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+
+  canvas.addEventListener('pointerdown', pointerDown);
+  startBtn.addEventListener('click', startGame);
+  document.getElementById('backBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
+});

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button onclick="window.location.href='scenarios.html'">← Back</button>
+    <button id="backBtn">← Back</button>
     <h2>Point Drill 0.25 sec Look</h2>
     <button id="startBtn">Start</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -1,7 +1,4 @@
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
-const startBtn = document.getElementById('startBtn');
-const result = document.getElementById('result');
+let canvas, ctx, startBtn, result;
 
 let playing = false;
 let awaitingClick = false;
@@ -127,5 +124,16 @@ function endGame() {
   startBtn.disabled = false;
 }
 
-canvas.addEventListener('pointerdown', pointerDown);
-startBtn.addEventListener('click', startGame);
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+
+  canvas.addEventListener('pointerdown', pointerDown);
+  startBtn.addEventListener('click', startGame);
+  document.getElementById('backBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
+});

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button onclick="window.location.href='scenarios.html'">← Back</button>
+    <button id="backBtn">← Back</button>
     <h2>Point Drill 0.5 sec Look</h2>
     <button id="startBtn">Start</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -1,7 +1,4 @@
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
-const startBtn = document.getElementById('startBtn');
-const result = document.getElementById('result');
+let canvas, ctx, startBtn, result;
 
 let playing = false;
 let awaitingClick = false;
@@ -127,5 +124,16 @@ function endGame() {
   startBtn.disabled = false;
 }
 
-canvas.addEventListener('pointerdown', pointerDown);
-startBtn.addEventListener('click', startGame);
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+
+  canvas.addEventListener('pointerdown', pointerDown);
+  startBtn.addEventListener('click', startGame);
+  document.getElementById('backBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
+});

--- a/practice.html
+++ b/practice.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div id="practiceScreen" class="screen practice-screen">
-    <button onclick="window.location.href='index.html'">← Back to Menu</button>
+    <button id="menuBtn">← Back to Menu</button>
     <h2>Memory Shape Drawing Game</h2>
     <div class="controls">
       <label>Time (sec):
@@ -63,9 +63,9 @@
     </div>
 
     <div class="controls">
-      <button onclick="newShape()">New Shape</button>
-      <button onclick="previousShape()">Previous Shape</button>
-      <button onclick="retryShape()">Retry Shape</button>
+      <button id="newShapeBtn">New Shape</button>
+      <button id="previousShapeBtn">Previous Shape</button>
+      <button id="retryShapeBtn">Retry Shape</button>
     </div>
 
     <canvas id="gameCanvas" width="500" height="500"></canvas>

--- a/scenario.js
+++ b/scenario.js
@@ -149,6 +149,47 @@ document.addEventListener('DOMContentLoaded', () => {
     applyScenario();
     showScreen('scenarioScreen');
   });
+
+  const backScenarioBtn = document.getElementById('scenarioBackBtn');
+  if (backScenarioBtn) {
+    backScenarioBtn.addEventListener('click', () => {
+      window.location.href = 'scenarios.html';
+    });
+  }
+
+  const startBtn = document.getElementById('startBtn');
+  if (startBtn) {
+    const params = new URLSearchParams(window.location.search);
+    const name = params.get('name') || '';
+    const titleEl = document.getElementById('scenarioTitle');
+    if (titleEl) titleEl.textContent = name || 'Scenario';
+    const scn = getScenario(name);
+    if (!scn) {
+      document.getElementById('result').textContent = 'Scenario not found.';
+      startBtn.disabled = true;
+    } else {
+      document.getElementById('timeInput').value = scn.time;
+      document.getElementById('bufferInput').value = scn.buffer;
+      document.getElementById('challengeInput').value = scn.challenge;
+      document.getElementById('sidesSelect').value = scn.sides;
+      document.getElementById('sizeSelect').value = scn.size;
+      document.getElementById('gridSelect').value = scn.grid;
+      document.getElementById('drawModeToggle').checked = scn.drawMode;
+      document.getElementById('drawModeLabel').textContent = scn.drawMode ? 'Point-to-Point' : 'Freehand';
+      document.getElementById('giveHighest').checked = scn.giveHighest;
+      document.getElementById('giveLowest').checked = scn.giveLowest;
+      document.getElementById('giveLeftmost').checked = scn.giveLeftmost;
+      document.getElementById('giveRightmost').checked = scn.giveRightmost;
+      document.getElementById('afterSelect').value = scn.afterAction || 'end';
+      document.getElementById('thresholdPoints').value = scn.thresholdPoints || 1;
+      document.getElementById('thresholdGrade').value = scn.thresholdGrade || 'green';
+      toggleThreshold();
+    }
+    startBtn.addEventListener('click', () => {
+      result.textContent = '';
+      startScenario();
+    });
+  }
 });
 
 function startScenario(repeat = false) {

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button onclick="window.location.href='scenarios.html'">← Back</button>
+    <button id="scenarioBackBtn">← Back</button>
     <h2 id="scenarioTitle">Scenario</h2>
     <button id="startBtn">Start Challenge</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>
@@ -62,37 +62,5 @@
   <script src="app.js"></script>
   <script src="scenario.js"></script>
   <script src="scenarios.js"></script>
-  <script>
-    const params = new URLSearchParams(window.location.search);
-    const name = params.get('name') || '';
-    document.getElementById('scenarioTitle').textContent = name || 'Scenario';
-    const scn = getScenario(name);
-    const startBtn = document.getElementById('startBtn');
-    if (!scn) {
-      document.getElementById('result').textContent = 'Scenario not found.';
-      startBtn.disabled = true;
-    } else {
-      document.getElementById('timeInput').value = scn.time;
-      document.getElementById('bufferInput').value = scn.buffer;
-      document.getElementById('challengeInput').value = scn.challenge;
-      document.getElementById('sidesSelect').value = scn.sides;
-      document.getElementById('sizeSelect').value = scn.size;
-      document.getElementById('gridSelect').value = scn.grid;
-      document.getElementById('drawModeToggle').checked = scn.drawMode;
-      document.getElementById('drawModeLabel').textContent = scn.drawMode ? 'Point-to-Point' : 'Freehand';
-      document.getElementById('giveHighest').checked = scn.giveHighest;
-      document.getElementById('giveLowest').checked = scn.giveLowest;
-      document.getElementById('giveLeftmost').checked = scn.giveLeftmost;
-      document.getElementById('giveRightmost').checked = scn.giveRightmost;
-      document.getElementById('afterSelect').value = scn.afterAction || 'end';
-      document.getElementById('thresholdPoints').value = scn.thresholdPoints || 1;
-      document.getElementById('thresholdGrade').value = scn.thresholdGrade || 'green';
-      toggleThreshold();
-    }
-    startBtn.addEventListener('click', () => {
-      result.textContent = '';
-      startScenario();
-    });
-  </script>
 </body>
 </html>

--- a/scenarios.html
+++ b/scenarios.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="menu-screen">
-    <button onclick="window.location.href='index.html'">← Back to Menu</button>
+    <button id="menuBtn">← Back to Menu</button>
     <h2>Scenarios</h2>
     <div class="controls">
       <label>Choose Scenario:
@@ -20,43 +20,5 @@
     </div>
   </div>
   <script src="scenarios.js"></script>
-  <script>
-    function loadScenarioList() {
-      const list = document.getElementById('scenarioList');
-      list.innerHTML = '';
-      getScenarioNames().forEach(name => {
-        const opt = document.createElement('option');
-        opt.value = name;
-        opt.textContent = name;
-        list.appendChild(opt);
-      });
-    }
-    function playSelectedScenario() {
-      const name = document.getElementById('scenarioList').value;
-      if (!name) return;
-      if (name === 'Angle Challenge') {
-        window.location.href = 'angles.html';
-      } else if (name === 'Angle Challenge (10\u00B0 increments)') {
-        window.location.href = 'angles.html?step=10';
-      } else if (name === 'Inch Drill') {
-        window.location.href = 'inch_warmup.html';
-      } else if (name === 'Point Drill 0.5 sec Look') {
-        window.location.href = 'point_drill_05.html';
-      } else if (name === 'Point Drill 0.25 sec Look') {
-        window.location.href = 'point_drill_025.html';
-      } else if (name === 'Point Drill 0.1 sec Look') {
-        window.location.href = 'point_drill_01.html';
-      } else {
-        window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);
-      }
-    }
-    document.getElementById('playBtn').addEventListener('click', playSelectedScenario);
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', loadScenarioList);
-    } else {
-      loadScenarioList();
-    }
-  </script>
 </body>
 </html>

--- a/scenarios.js
+++ b/scenarios.js
@@ -18,3 +18,43 @@ function getScenario(name) {
 function getScenarioNames() {
   return [...Object.keys(builtInScenarios), ...Object.keys(getSavedScenarios())];
 }
+
+function loadScenarioList() {
+  const list = document.getElementById('scenarioList');
+  if (!list) return;
+  list.innerHTML = '';
+  getScenarioNames().forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    list.appendChild(opt);
+  });
+}
+
+function playSelectedScenario() {
+  const name = document.getElementById('scenarioList')?.value;
+  if (!name) return;
+  if (name === 'Angle Challenge') {
+    window.location.href = 'angles.html';
+  } else if (name === 'Angle Challenge (10\u00B0 increments)') {
+    window.location.href = 'angles.html?step=10';
+  } else if (name === 'Inch Drill') {
+    window.location.href = 'inch_warmup.html';
+  } else if (name === 'Point Drill 0.5 sec Look') {
+    window.location.href = 'point_drill_05.html';
+  } else if (name === 'Point Drill 0.25 sec Look') {
+    window.location.href = 'point_drill_025.html';
+  } else if (name === 'Point Drill 0.1 sec Look') {
+    window.location.href = 'point_drill_01.html';
+  } else {
+    window.location.href = 'scenario_play.html?name=' + encodeURIComponent(name);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('playBtn')?.addEventListener('click', playSelectedScenario);
+  document.getElementById('menuBtn')?.addEventListener('click', () => {
+    window.location.href = 'index.html';
+  });
+  if (document.getElementById('scenarioList')) loadScenarioList();
+});


### PR DESCRIPTION
## Summary
- replace inline HTML `onclick` handlers with script-driven navigation
- wire up page controls after DOM load
- centralize scenario selection and play logic in scripts

## Testing
- `node --check app.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b6d36a2448325b724cb79966eb092