### PR TITLE
Add localStorage high score tracking and menu display

### DIFF
--- a/app.js
+++ b/app.js
@@ -206,7 +206,12 @@ function evaluatePointToPoint() {
     ctx.fillText(i + 1, p.x + 6, p.y - 6);
   });
   const avg = playerShape.length ? totalDist / playerShape.length : 0;
-  result.textContent = `Average error: ${avg.toFixed(1)} px`;
+  let best = parseFloat(localStorage.getItem('p2pBest'));
+  if (isNaN(best) || avg < best) {
+    best = avg;
+    localStorage.setItem('p2pBest', best.toString());
+  }
+  result.textContent = `Average error: ${avg.toFixed(1)} px (Best: ${best.toFixed(1)} px)`;
 }
 
 function evaluateFreehand() {
@@ -230,7 +235,12 @@ function evaluateFreehand() {
     ctx.stroke();
   }
   const avg = totalDist / (playerShape.length - 1);
-  result.textContent = `Average error: ${avg.toFixed(1)} px`;
+  let best = parseFloat(localStorage.getItem('freehandBest'));
+  if (isNaN(best) || avg < best) {
+    best = avg;
+    localStorage.setItem('freehandBest', best.toString());
+  }
+  result.textContent = `Average error: ${avg.toFixed(1)} px (Best: ${best.toFixed(1)} px)`;
 }
 
 function distanceToPolygon(p, poly) {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
     <button id="practiceBtn">Practice</button>
     <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>
+    <div id="highScores">
+      <h2>High Scores</h2>
+      <p>Point-to-Point: <span id="p2pBest">N/A</span></p>
+      <p>Freehand: <span id="freehandBest">N/A</span></p>
+    </div>
   </div>
   <script src="index.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const p2pBest = localStorage.getItem('p2pBest');
+  const freehandBest = localStorage.getItem('freehandBest');
+  const p2pEl = document.getElementById('p2pBest');
+  const freeEl = document.getElementById('freehandBest');
+  if (p2pEl) p2pEl.textContent = p2pBest ? `${parseFloat(p2pBest).toFixed(1)} px` : 'N/A';
+  if (freeEl) freeEl.textContent = freehandBest ? `${parseFloat(freehandBest).toFixed(1)} px` : 'N/A';
   document.getElementById('practiceBtn')?.addEventListener('click', () => {
     window.location.href = 'practice.html';
   });


### PR DESCRIPTION
## Summary
- track and persist best average errors for point-to-point and freehand modes
- surface stored high scores on the main menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7303702c8325a1c7121c6562f78f