### PR TITLE
refactor: centralize canvas utilities

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,19 @@
-let canvas, ctx, drawModeToggle, drawModeLabel, gridSelect, result;
+import { getCanvasPos, clearCanvas } from './src/utils.js';
 
-let originalShape = [];
-let playerShape = [];
+export let canvas, ctx, drawModeToggle, drawModeLabel, gridSelect, result;
+
+export let originalShape = [];
+export let playerShape = [];
 let isDrawing = false;
-let drawingEnabled = false;
-let lastShape = [];
-let viewTimer = null;
+export let drawingEnabled = false;
+export let lastShape = [];
+export let viewTimer = null;
+
+export function setPlayerShape(shape) { playerShape = shape; }
+export function setOriginalShape(shape) { originalShape = shape; }
+export function setDrawingEnabled(val) { drawingEnabled = val; }
+export function setLastShape(shape) { lastShape = shape; }
+export function setViewTimer(timer) { viewTimer = timer; }
 
 document.addEventListener('DOMContentLoaded', () => {
   canvas = document.getElementById('gameCanvas');
@@ -24,7 +32,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   canvas.addEventListener('pointerdown', (e) => {
     if (!drawingEnabled) return;
-    const pos = getCanvasPos(e);
+    const pos = getCanvasPos(canvas, e);
     if (drawModeToggle?.checked) {
       playerShape.push(pos);
       drawDots();
@@ -40,7 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   canvas.addEventListener('pointermove', (e) => {
     if (!drawingEnabled || drawModeToggle?.checked || !isDrawing) return;
-    const pos = getCanvasPos(e);
+    const pos = getCanvasPos(canvas, e);
     playerShape.push(pos);
     drawFreehand();
   });
@@ -59,14 +67,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-function getCanvasPos(e) {
-  const rect = canvas.getBoundingClientRect();
-  return {
-    x: e.clientX - rect.left,
-    y: e.clientY - rect.top
-  };
-}
-
 function getTimeMs() {
   const sec = parseFloat(document.getElementById("timeInput").value);
   return Math.max(1000, sec * 1000);
@@ -82,11 +82,11 @@ function newShape() {
   playerShape = [];
   drawingEnabled = false;
   result.textContent = "";
-  clearCanvas();
+  clearCanvas(ctx);
   drawGrid();
   drawShape(originalShape, "black");
   viewTimer = setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     drawGrid();
     drawGivenPoints(originalShape);
     drawingEnabled = true;
@@ -100,12 +100,12 @@ function previousShape() {
   playerShape = [];
   drawingEnabled = false;
   result.textContent = "";
-  clearCanvas();
+  clearCanvas(ctx);
   drawGrid();
   drawShape(originalShape, "black");
   const time = getTimeMs();
   viewTimer = setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     drawGrid();
     drawGivenPoints(originalShape);
     drawingEnabled = true;
@@ -118,22 +118,18 @@ function retryShape() {
   playerShape = [];
   drawingEnabled = false;
   result.textContent = "";
-  clearCanvas();
+  clearCanvas(ctx);
   drawGrid();
   drawShape(originalShape, "black");
   viewTimer = setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     drawGrid();
     drawGivenPoints(originalShape);
     drawingEnabled = true;
   }, time);
 }
 
-function clearCanvas() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-}
-
-function drawGrid() {
+export function drawGrid() {
   const gridVal = parseInt(gridSelect.value);
   if (gridVal < 2) return;
   const spacing = canvas.width / gridVal;
@@ -146,14 +142,14 @@ function drawGrid() {
   }
 }
 
-function drawShape(points, color) {
+export function drawShape(points, color) {
   if (points.length === 1) { drawDot(points[0], color); return; }
   ctx.beginPath(); ctx.moveTo(points[0].x, points[0].y);
   for (let i = 1; i < points.length; i++) ctx.lineTo(points[i].x, points[i].y);
   ctx.closePath(); ctx.fillStyle = color; ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.fill(); ctx.stroke();
 }
 
-function drawGivenPoints(points) {
+export function drawGivenPoints(points) {
   const extremes = {
     top: points.reduce((a, b) => (a.y < b.y ? a : b)),
     bottom: points.reduce((a, b) => (a.y > b.y ? a : b)),
@@ -171,14 +167,14 @@ function drawDot(pt, color) {
 }
 
 function drawDots() {
-  clearCanvas(); drawGrid();
+  clearCanvas(ctx); drawGrid();
   drawGivenPoints(originalShape);
   playerShape.forEach(pt => drawDot(pt, "red"));
 }
 
-function revealShape() {
+export function revealShape() {
   drawingEnabled = false;
-  clearCanvas();
+  clearCanvas(ctx);
   drawGrid();
   drawShape(originalShape, "black");
   if (drawModeToggle.checked) {
@@ -245,7 +241,7 @@ function distanceToPolygon(p, poly) {
 }
 
 function drawFreehand() {
-  clearCanvas(); drawGrid(); drawGivenPoints(originalShape);
+  clearCanvas(ctx); drawGrid(); drawGivenPoints(originalShape);
   if (playerShape.length < 2) return;
   ctx.beginPath(); ctx.moveTo(playerShape[0].x, playerShape[0].y);
   for (let i = 1; i < playerShape.length; i++) ctx.lineTo(playerShape[i].x, playerShape[i].y);

--- a/inch_warmup.html
+++ b/inch_warmup.html
@@ -15,6 +15,6 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
-  <script src="inch_warmup.js"></script>
+  <script type="module" src="inch_warmup.js"></script>
 </body>
 </html>

--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -14,6 +14,6 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
-  <script src="point_drill_01.js"></script>
+  <script type="module" src="point_drill_01.js"></script>
 </body>
 </html>

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -14,6 +14,6 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
-  <script src="point_drill_025.js"></script>
+  <script type="module" src="point_drill_025.js"></script>
 </body>
 </html>

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -1,3 +1,5 @@
+import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+
 let canvas, ctx, startBtn, result;
 
 let playing = false;
@@ -9,58 +11,23 @@ let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
-function getCanvasPos(e) {
-  const rect = canvas.getBoundingClientRect();
-  return { x: e.clientX - rect.left, y: e.clientY - rect.top };
-}
-
-function clearCanvas() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-}
-
 function drawTarget() {
   const margin = 20;
   target = {
     x: Math.random() * (canvas.width - 2 * margin) + margin,
     y: Math.random() * (canvas.height - 2 * margin) + margin
   };
-  clearCanvas();
+  clearCanvas(ctx);
   ctx.fillStyle = 'black';
   ctx.beginPath();
   ctx.arc(target.x, target.y, 5, 0, Math.PI * 2);
   ctx.fill();
   setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     awaitingClick = true;
   }, 250);
 }
 
-function playSound(grade) {
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.connect(gain).connect(audioCtx.destination);
-  const now = audioCtx.currentTime;
-  if (grade === 'green') {
-    osc.frequency.setValueAtTime(800, now);
-    gain.gain.setValueAtTime(1, now);
-    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
-    osc.start(now);
-    osc.stop(now + 0.1);
-  } else if (grade === 'yellow') {
-    osc.frequency.setValueAtTime(400, now);
-    gain.gain.setValueAtTime(0.6, now);
-    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
-    osc.start(now);
-    osc.stop(now + 0.15);
-  } else {
-    osc.frequency.setValueAtTime(200, now);
-    osc.frequency.linearRampToValueAtTime(100, now + 0.3);
-    gain.gain.setValueAtTime(0.7, now);
-    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
-    osc.start(now);
-    osc.stop(now + 0.3);
-  }
-}
 
 function flashTarget(callback) {
   ctx.save();
@@ -70,7 +37,7 @@ function flashTarget(callback) {
   ctx.fill();
   ctx.restore();
   setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     callback();
   }, 300);
 }
@@ -78,7 +45,7 @@ function flashTarget(callback) {
 function pointerDown(e) {
   if (!awaitingClick) return;
   awaitingClick = false;
-  const pos = getCanvasPos(e);
+  const pos = getCanvasPos(canvas, e);
   const d = Math.hypot(pos.x - target.x, pos.y - target.y);
   stats.totalErr += d;
   stats.totalPoints++;
@@ -92,7 +59,7 @@ function pointerDown(e) {
   } else {
     stats.red++;
   }
-  playSound(grade);
+  playSound(audioCtx, grade);
   flashTarget(() => {
     if (Date.now() < endTime) {
       drawTarget();
@@ -118,7 +85,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
-  clearCanvas();
+  clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
   startBtn.disabled = false;

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -14,6 +14,6 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
-  <script src="point_drill_05.js"></script>
+  <script type="module" src="point_drill_05.js"></script>
 </body>
 </html>

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -1,3 +1,5 @@
+import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+
 let canvas, ctx, startBtn, result;
 
 let playing = false;
@@ -9,58 +11,23 @@ let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
-function getCanvasPos(e) {
-  const rect = canvas.getBoundingClientRect();
-  return { x: e.clientX - rect.left, y: e.clientY - rect.top };
-}
-
-function clearCanvas() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-}
-
 function drawTarget() {
   const margin = 20;
   target = {
     x: Math.random() * (canvas.width - 2 * margin) + margin,
     y: Math.random() * (canvas.height - 2 * margin) + margin
   };
-  clearCanvas();
+  clearCanvas(ctx);
   ctx.fillStyle = 'black';
   ctx.beginPath();
   ctx.arc(target.x, target.y, 5, 0, Math.PI * 2);
   ctx.fill();
   setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     awaitingClick = true;
   }, 500);
 }
 
-function playSound(grade) {
-  const osc = audioCtx.createOscillator();
-  const gain = audioCtx.createGain();
-  osc.connect(gain).connect(audioCtx.destination);
-  const now = audioCtx.currentTime;
-  if (grade === 'green') {
-    osc.frequency.setValueAtTime(800, now);
-    gain.gain.setValueAtTime(1, now);
-    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
-    osc.start(now);
-    osc.stop(now + 0.1);
-  } else if (grade === 'yellow') {
-    osc.frequency.setValueAtTime(400, now);
-    gain.gain.setValueAtTime(0.6, now);
-    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
-    osc.start(now);
-    osc.stop(now + 0.15);
-  } else {
-    osc.frequency.setValueAtTime(200, now);
-    osc.frequency.linearRampToValueAtTime(100, now + 0.3);
-    gain.gain.setValueAtTime(0.7, now);
-    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
-    osc.start(now);
-    osc.stop(now + 0.3);
-  }
-}
 
 function flashTarget(callback) {
   ctx.save();
@@ -70,7 +37,7 @@ function flashTarget(callback) {
   ctx.fill();
   ctx.restore();
   setTimeout(() => {
-    clearCanvas();
+    clearCanvas(ctx);
     callback();
   }, 300);
 }
@@ -78,7 +45,7 @@ function flashTarget(callback) {
 function pointerDown(e) {
   if (!awaitingClick) return;
   awaitingClick = false;
-  const pos = getCanvasPos(e);
+  const pos = getCanvasPos(canvas, e);
   const d = Math.hypot(pos.x - target.x, pos.y - target.y);
   stats.totalErr += d;
   stats.totalPoints++;
@@ -92,7 +59,7 @@ function pointerDown(e) {
   } else {
     stats.red++;
   }
-  playSound(grade);
+  playSound(audioCtx, grade);
   flashTarget(() => {
     if (Date.now() < endTime) {
       drawTarget();
@@ -118,7 +85,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
-  clearCanvas();
+  clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
   startBtn.disabled = false;

--- a/practice.html
+++ b/practice.html
@@ -73,6 +73,6 @@
   </div>
 
   <script src="geometry.js"></script>
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/scenario.js
+++ b/scenario.js
@@ -1,3 +1,25 @@
+import { clearCanvas } from './src/utils.js';
+import {
+  canvas,
+  ctx,
+  result,
+  originalShape,
+  playerShape,
+  drawingEnabled,
+  lastShape,
+  viewTimer,
+  drawGrid,
+  drawShape,
+  drawGivenPoints,
+  revealShape,
+  setPlayerShape,
+  setOriginalShape,
+  setDrawingEnabled,
+  setLastShape,
+  setViewTimer
+} from './app.js';
+import { getScenario } from './scenarios.js';
+
 let scenarioTimer = null;
 let scoreSummary = { totalDist: 0, totalPoints: 0 };
 let scenarioConfig = null;
@@ -211,26 +233,26 @@ function startScenario(repeat = false) {
   }
 
   if (!repeat) {
-    lastShape = originalShape.map(p => ({ ...p }));
+    setLastShape(originalShape.map(p => ({ ...p })));
     const size = document.getElementById('sizeSelect').value;
-    originalShape = generateShape(sides, canvas.width, canvas.height, size);
+    setOriginalShape(generateShape(sides, canvas.width, canvas.height, size));
   }
-  playerShape = [];
-  drawingEnabled = false;
+  setPlayerShape([]);
+  setDrawingEnabled(false);
   result.textContent = '';
-  clearCanvas();
+  clearCanvas(ctx);
   drawGrid();
   drawShape(originalShape, 'black');
 
-  viewTimer = setTimeout(() => {
-    clearCanvas();
+  setViewTimer(setTimeout(() => {
+    clearCanvas(ctx);
     drawGrid();
     drawGivenPoints(originalShape);
     setTimeout(() => {
-      drawingEnabled = true;
+      setDrawingEnabled(true);
       scenarioTimer = setTimeout(() => {
         revealShape();
       }, challengeLength);
     }, bufferTime);
-  }, lookTime);
+  }, lookTime));
 }

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -60,8 +60,7 @@
     </div>
   </div>
   <script src="geometry.js"></script>
-  <script src="app.js"></script>
-  <script src="scenario.js"></script>
-  <script src="scenarios.js"></script>
+  <script type="module" src="app.js"></script>
+  <script type="module" src="scenario.js"></script>
 </body>
 </html>

--- a/scenarios.html
+++ b/scenarios.html
@@ -19,6 +19,6 @@
       <button id="playBtn">Play Scenario</button>
     </div>
   </div>
-  <script src="scenarios.js"></script>
+  <script type="module" src="scenarios.js"></script>
 </body>
 </html>

--- a/scenarios.js
+++ b/scenarios.js
@@ -11,7 +11,7 @@ function getSavedScenarios() {
   return JSON.parse(localStorage.getItem('scenarios') || '{}');
 }
 
-function getScenario(name) {
+export function getScenario(name) {
   return builtInScenarios[name] || getSavedScenarios()[name];
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,35 @@
+export function getCanvasPos(canvas, e) {
+  const rect = canvas.getBoundingClientRect();
+  return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+}
+
+export function clearCanvas(ctx) {
+  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+}
+
+export function playSound(audioCtx, grade) {
+  const osc = audioCtx.createOscillator();
+  const gain = audioCtx.createGain();
+  osc.connect(gain).connect(audioCtx.destination);
+  const now = audioCtx.currentTime;
+  if (grade === 'green') {
+    osc.frequency.setValueAtTime(800, now);
+    gain.gain.setValueAtTime(1, now);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
+    osc.start(now);
+    osc.stop(now + 0.1);
+  } else if (grade === 'yellow') {
+    osc.frequency.setValueAtTime(400, now);
+    gain.gain.setValueAtTime(0.6, now);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
+    osc.start(now);
+    osc.stop(now + 0.15);
+  } else {
+    osc.frequency.setValueAtTime(200, now);
+    osc.frequency.linearRampToValueAtTime(100, now + 0.3);
+    gain.gain.setValueAtTime(0.7, now);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+    osc.start(now);
+    osc.stop(now + 0.3);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable canvas helpers and sound playback in `src/utils.js`
- refactor game scripts to import shared helpers
- switch pages and scenario logic to ES modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b72f33d308325bc87d0a1edc39445