### PR TITLE
Add manifest and service worker with SVG icon

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>About - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="menu-screen">

--- a/angles.html
+++ b/angles.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Angle Challenge Drill</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="practice-screen">

--- a/angles.js
+++ b/angles.js
@@ -117,4 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.title = title;
   }
   startBtn.addEventListener('click', startGame);
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
 });

--- a/app.js
+++ b/app.js
@@ -281,3 +281,9 @@ function drawFreehand() {
   for (let i = 1; i < playerShape.length; i++) ctx.lineTo(playerShape[i].x, playerShape[i].y);
   ctx.strokeStyle = "red"; ctx.lineWidth = 1.5; ctx.stroke();
 }
+
+window.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+});

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#222"/>
+  <circle cx="256" cy="256" r="200" fill="#4CAF50"/>
+</svg>

--- a/inch_warmup.html
+++ b/inch_warmup.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Inch Drill - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="practice-screen">

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -182,3 +182,9 @@ canvas.addEventListener('pointerdown', pointerDown);
 canvas.addEventListener('pointermove', pointerMove);
 canvas.addEventListener('pointerup', pointerUp);
 startBtn.addEventListener('click', startGame);
+
+window.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+});

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <!-- MENU SCREEN -->

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Memory Drawing Game",
+  "short_name": "MemDraw",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    { "src": "icon.svg", "sizes": "192x192", "type": "image/svg+xml" },
+    { "src": "icon.svg", "sizes": "512x512", "type": "image/svg+xml" }
+  ]
+}

--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Point Drill 0.1 sec Look - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="practice-screen">

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -129,3 +129,9 @@ function endGame() {
 
 canvas.addEventListener('pointerdown', pointerDown);
 startBtn.addEventListener('click', startGame);
+
+window.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+});

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Point Drill 0.25 sec Look - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="practice-screen">

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -129,3 +129,9 @@ function endGame() {
 
 canvas.addEventListener('pointerdown', pointerDown);
 startBtn.addEventListener('click', startGame);
+
+window.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+});

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Point Drill 0.5 sec Look - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="practice-screen">

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -129,3 +129,9 @@ function endGame() {
 
 canvas.addEventListener('pointerdown', pointerDown);
 startBtn.addEventListener('click', startGame);
+
+window.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+});

--- a/practice.html
+++ b/practice.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Practice - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div id="practiceScreen" class="screen practice-screen">

--- a/scenario.js
+++ b/scenario.js
@@ -149,6 +149,9 @@ document.addEventListener('DOMContentLoaded', () => {
     applyScenario();
     showScreen('scenarioScreen');
   });
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
 });
 
 function startScenario(repeat = false) {

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Play Scenario - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="practice-screen">

--- a/scenarios.html
+++ b/scenarios.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Scenarios - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="manifest" href="manifest.json">
 </head>
 <body>
   <div class="menu-screen">

--- a/scenarios.js
+++ b/scenarios.js
@@ -18,3 +18,9 @@ function getScenario(name) {
 function getScenarioNames() {
   return [...Object.keys(builtInScenarios), ...Object.keys(getSavedScenarios())];
 }
+
+window.addEventListener('DOMContentLoaded', () => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('service-worker.js');
+  }
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,45 @@
+const CACHE_NAME = 'mdg-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/about.html',
+  '/practice.html',
+  '/angles.html',
+  '/inch_warmup.html',
+  '/point_drill_01.html',
+  '/point_drill_05.html',
+  '/point_drill_025.html',
+  '/scenarios.html',
+  '/scenario_play.html',
+  '/style.css',
+  '/app.js',
+  '/angles.js',
+  '/inch_warmup.js',
+  '/point_drill_01.js',
+  '/point_drill_05.js',
+  '/point_drill_025.js',
+  '/scenario.js',
+  '/scenarios.js',
+  '/icon.svg',
+  '/manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- Define PWA manifest with SVG icon
- Cache static assets and SVG icon in service worker
- Replace binary PNG icons with text-based SVG for PR compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6d220b248325a9c12ac58b953247