### PR TITLE
Refactor geometry module to ES modules

### DIFF
--- a/__tests__/geometry.test.js
+++ b/__tests__/geometry.test.js
@@ -1,4 +1,4 @@
-const { generateShape, distancePointToSegment } = require('../geometry');
+import { generateShape, distancePointToSegment } from '../geometry.js';
 
 describe('generateShape', () => {
   const width = 500;

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas } from './src/utils.js';
+import { generateShape, distancePointToSegment } from './geometry.js';
 
 export let canvas, ctx, drawModeToggle, drawModeLabel, gridSelect, result;
 

--- a/geometry.js
+++ b/geometry.js
@@ -1,4 +1,4 @@
-function generateShape(sides, width, height, size = 'medium') {
+export function generateShape(sides, width, height, size = 'medium') {
   if (sides === 1) {
     return [{
       x: Math.random() * (width - 40) + 20,
@@ -32,7 +32,7 @@ function generateShape(sides, width, height, size = 'medium') {
   return points;
 }
 
-function distancePointToSegment(p, a, b) {
+export function distancePointToSegment(p, a, b) {
   const ab = { x: b.x - a.x, y: b.y - a.y };
   const ap = { x: p.x - a.x, y: p.y - a.y };
   const abLenSq = ab.x * ab.x + ab.y * ab.y;
@@ -42,9 +42,3 @@ function distancePointToSegment(p, a, b) {
   return Math.hypot(p.x - proj.x, p.y - proj.y);
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = { generateShape, distancePointToSegment };
-} else {
-  window.generateShape = (sides, width, height, size) => generateShape(sides, width, height, size);
-  window.distancePointToSegment = distancePointToSegment;
-}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "memory-drawing-game",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "jest": "^30.0.5"

--- a/practice.html
+++ b/practice.html
@@ -72,7 +72,6 @@
     <p class="score" id="result"></p>
   </div>
 
-  <script src="geometry.js"></script>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/scenario.js
+++ b/scenario.js
@@ -1,4 +1,5 @@
 import { clearCanvas } from './src/utils.js';
+import { generateShape } from './geometry.js';
 import {
   canvas,
   ctx,

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -59,7 +59,6 @@
       <span id="thresholdWrapper"></span>
     </div>
   </div>
-  <script src="geometry.js"></script>
   <script type="module" src="app.js"></script>
   <script type="module" src="scenario.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- convert `geometry.js` to a true ES module
- import geometry helpers in `app.js` and `scenario.js`
- drop standalone geometry script tags from HTML
- enable ESM-aware Jest tests

## Testing
- `npm test`
- `node - <<'NODE'
...browser script output...
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689b8011a1e483258c1dd590c77771bb