### PR TITLE
Handle invalid saved scenarios in dropdown

### DIFF
--- a/scenarios.js
+++ b/scenarios.js
@@ -8,7 +8,12 @@ const builtInScenarios = {
 };
 
 function getSavedScenarios() {
-  return JSON.parse(localStorage.getItem('scenarios') || '{}');
+  try {
+    return JSON.parse(localStorage.getItem('scenarios') || '{}');
+  } catch (err) {
+    console.warn('Failed to parse saved scenarios:', err);
+    return {};
+  }
 }
 
 export function getScenario(name) {


### PR DESCRIPTION
## Summary
- Safely parse saved scenarios using try/catch
- Log parsing failures and fall back to default scenarios

## Testing
- `node - <<'NODE' ...` (invalid JSON)
- `node - <<'NODE' ...` (no saved data)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b801624c0832584a90c70f755f856