### PR TITLE
Add graded audio/visual feedback to angle challenge

### DIFF
--- a/angles.html
+++ b/angles.html
@@ -15,6 +15,6 @@
     <div id="angleOptions" class="angle-options"></div>
     <p class="score" id="angleResult"></p>
   </div>
-  <script src="angles.js"></script>
+  <script type="module" src="angles.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -147,6 +147,15 @@ h2, h1 { margin: 10px 0; }
   font-size: 18px;
 }
 
+.angle-option.close .box::after {
+  content: '!';
+  color: gold;
+  position: absolute;
+  left: 3px;
+  top: -3px;
+  font-size: 18px;
+}
+
 .angle-option.incorrect .box::after {
   content: '\2717';
   color: red;


### PR DESCRIPTION
## Summary
- Show player's selected angle over the target with color-coded feedback
- Play success, near-miss, or miss tones using existing point drill sounds
- Support a new "close" state for UI options and load angles.js as module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9447ef208325b05b0098caeac60b