### PR TITLE
Add return to menu button on practice screen

### DIFF
--- a/practice.html
+++ b/practice.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div id="practiceScreen" class="screen practice-screen">
-    <button id="menuBtn">← Back to Menu</button>
+    <button id="menuBtn">Return to Menu</button>
     <h2>Memory Shape Drawing Game</h2>
     <div class="controls">
       <label>Time (sec):


### PR DESCRIPTION
## Summary
- replace practice screen heading button with a clear "Return to Menu" button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f9da3b4b88325a9383b5d20499851