### PR TITLE
Improve mobile responsiveness for drawing game

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,11 @@
 export function getCanvasPos(canvas, e) {
   const rect = canvas.getBoundingClientRect();
-  return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
+  return {
+    x: (e.clientX - rect.left) * scaleX,
+    y: (e.clientY - rect.top) * scaleY
+  };
 }
 
 export function clearCanvas(ctx) {

--- a/style.css
+++ b/style.css
@@ -4,13 +4,12 @@ html, body {
   font-family: sans-serif;
   background-color: #f0f0f0;
   user-select: none;
-  touch-action: none;
-  height: 100%;
+  min-height: 100%;
 }
 .screen {
   display: none;
   width: 100%;
-  height: 100%;
+  min-height: 100vh;
   box-sizing: border-box;
   padding: 10px;
 }
@@ -29,6 +28,9 @@ canvas {
   background: white;
   border: 1px solid red;
   border-radius: 6px;
+  width: min(90vmin, 500px);
+  height: min(90vmin, 500px);
+  touch-action: none;
 }
 .controls, .switches-group, .checkboxes-group {
   display: flex;


### PR DESCRIPTION
## Summary
- Make screens and canvas responsive with viewport-based sizing
- Allow page scroll and restrict touch-action to the canvas
- Scale pointer coordinates to match resized canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9f5ffb688325a5146e38f288c960