### PR TITLE
feat: add audio feedback to freehand drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project is a small browser game where you try to memorize and recreate rand
 - **Size** – Small, Medium, or Big shapes.
 - **Grid** – Show an optional grid on the canvas.
 - **Point-to-Point / Freehand** – Toggle how you draw. Point-to-point lets you place dots; freehand lets you draw with the pointer.
+  In freehand mode, once you release your line a tone plays indicating how close your drawing was to the hidden shape.
 - **Highest/Lowest/Left-most/Right-most** – When checked, these reference points of the shape will remain visible while you draw.
 - **New Shape** – Generate a new random shape.
 - **Previous Shape** – View the last shape again.

--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
   canvas.addEventListener('pointerup', () => {
     if (!drawingEnabled || drawModeToggle?.checked) return;
     isDrawing = false;
+    audioCtx.resume();
     revealShape();
   });
 
@@ -201,6 +202,12 @@ function gradePoint(p) {
   return { color, sound, dist };
 }
 
+function gradeDistance(d) {
+  if (d <= 5) return 'green';
+  if (d <= 10) return 'yellow';
+  return 'red';
+}
+
 function drawDots() {
   clearCanvas(ctx); drawGrid();
   drawGivenPoints(originalShape);
@@ -265,6 +272,7 @@ function evaluateFreehand() {
     localStorage.setItem('freehandBest', best.toString());
   }
   result.textContent = `Average error: ${avg.toFixed(1)} px (Best: ${best.toFixed(1)} px)`;
+  playSound(audioCtx, gradeDistance(avg));
 }
 
 function distanceToPolygon(p, poly) {


### PR DESCRIPTION
## Summary
- play a tone after releasing a freehand line based on drawing accuracy
- document freehand mode's post-draw audio cue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa34fd2b483258a21feaab378f8be