### PR TITLE
Add global back button to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,8 +10,8 @@
   <div class="menu-screen">
     <h1>About</h1>
     <p>This project is a simple memory drawing game created by Sawyer Wall.</p>
-    <button id="menuBtn">Back to Menu</button>
+    <button id="backBtn">← Back</button>
   </div>
-  <script src="about.js"></script>
+  <script src="back.js"></script>
 </body>
 </html>

--- a/about.js
+++ b/about.js
@@ -1,5 +1,0 @@
-document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('menuBtn')?.addEventListener('click', () => {
-    window.location.href = 'index.html';
-  });
-});

--- a/angles.html
+++ b/angles.html
@@ -8,13 +8,14 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button id="backBtn">← Back to Scenarios</button>
+    <button id="backBtn">← Back</button>
     <h2>Angle Challenge Drill</h2>
     <button id="startBtn">Start</button>
     <canvas id="angleCanvas" width="500" height="500"></canvas>
     <div id="angleOptions" class="angle-options"></div>
     <p class="score" id="angleResult"></p>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="angles.js"></script>
 </body>
 </html>

--- a/angles.js
+++ b/angles.js
@@ -145,9 +145,6 @@ function nextAngle() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('backBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
-  });
   createOptions();
   if (step !== 5) {
     const title = `Angle Challenge Drill (${step}\u00B0 increments)`;

--- a/app.js
+++ b/app.js
@@ -68,9 +68,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('newShapeBtn')?.addEventListener('click', newShape);
   document.getElementById('previousShapeBtn')?.addEventListener('click', previousShape);
   document.getElementById('retryShapeBtn')?.addEventListener('click', retryShape);
-  document.getElementById('menuBtn')?.addEventListener('click', () => {
-    window.location.href = 'index.html';
-  });
 });
 
 function getTimeMs() {

--- a/back.js
+++ b/back.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('backBtn');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      if (document.referrer) {
+        window.history.back();
+      } else {
+        window.location.href = 'index.html';
+      }
+    });
+  }
+});

--- a/inch_warmup.html
+++ b/inch_warmup.html
@@ -15,6 +15,7 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="inch_warmup.js"></script>
 </body>
 </html>

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -43,9 +43,6 @@ document.addEventListener('DOMContentLoaded', () => {
   canvas.addEventListener('pointermove', pointerMove);
   canvas.addEventListener('pointerup', pointerUp);
   startBtn.addEventListener('click', startGame);
-  document.getElementById('backBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
-  });
 });
 
 function drawArrow() {

--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -14,6 +14,7 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="point_drill_01.js"></script>
 </body>
 </html>

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -104,7 +104,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);
-  document.getElementById('backBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
-  });
 });

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -14,6 +14,7 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="point_drill_025.js"></script>
 </body>
 </html>

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -104,7 +104,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);
-  document.getElementById('backBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
-  });
 });

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -14,6 +14,7 @@
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="point_drill_05.js"></script>
 </body>
 </html>

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -104,7 +104,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);
-  document.getElementById('backBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
-  });
 });

--- a/practice.html
+++ b/practice.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div id="practiceScreen" class="screen practice-screen">
-    <button id="menuBtn">Return to Menu</button>
+    <button id="backBtn">← Back</button>
     <h2>Memory Shape Drawing Game</h2>
     <div class="controls">
       <label>Time (sec):
@@ -72,6 +72,7 @@
     <p class="score" id="result"></p>
   </div>
 
+  <script src="back.js"></script>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/scenario.js
+++ b/scenario.js
@@ -173,13 +173,6 @@ document.addEventListener('DOMContentLoaded', () => {
     showScreen('scenarioScreen');
   });
 
-  const backScenarioBtn = document.getElementById('scenarioBackBtn');
-  if (backScenarioBtn) {
-    backScenarioBtn.addEventListener('click', () => {
-      window.location.href = 'scenarios.html';
-    });
-  }
-
   const startBtn = document.getElementById('startBtn');
   if (startBtn) {
     const params = new URLSearchParams(window.location.search);

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="practice-screen">
-    <button id="scenarioBackBtn">← Back</button>
+    <button id="backBtn">← Back</button>
     <h2 id="scenarioTitle">Scenario</h2>
     <button id="startBtn">Start Challenge</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>
@@ -59,6 +59,7 @@
       <span id="thresholdWrapper"></span>
     </div>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="app.js"></script>
   <script type="module" src="scenario.js"></script>
 </body>

--- a/scenarios.html
+++ b/scenarios.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div class="menu-screen">
-    <button id="menuBtn">← Back to Menu</button>
+    <button id="backBtn">← Back</button>
     <h2>Scenarios</h2>
     <div class="controls">
       <label>Choose Scenario:
@@ -19,6 +19,7 @@
       <button id="playBtn">Play Scenario</button>
     </div>
   </div>
+  <script src="back.js"></script>
   <script type="module" src="scenarios.js"></script>
 </body>
 </html>

--- a/scenarios.js
+++ b/scenarios.js
@@ -52,8 +52,5 @@ export function playSelectedScenario() {
 
 document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('playBtn')?.addEventListener('click', playSelectedScenario);
-  document.getElementById('menuBtn')?.addEventListener('click', () => {
-    window.location.href = 'index.html';
-  });
   if (document.getElementById('scenarioList')) loadScenarioList();
 });


### PR DESCRIPTION
## Summary
- Introduce `back.js` script to handle returning to previous page or menu
- Replace per-page navigation with consistent `← Back` buttons across drills and scenario pages
- Remove old button handlers and redundant about.js file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa474e9b483258aa2ab63dfbe9ba4