### PR TITLE
Revert mid-grade visuals to orange

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -92,7 +92,7 @@ function showSelection(angle, grade) {
   const x = centerX + length * Math.cos(rotation + angle * Math.PI / 180);
   const y = centerY + length * Math.sin(rotation + angle * Math.PI / 180);
   ctx.save();
-  ctx.strokeStyle = grade === 'green' ? 'green' : grade === 'yellow' ? 'yellow' : 'red';
+  ctx.strokeStyle = grade === 'green' ? 'green' : grade === 'yellow' ? 'orange' : 'red';
   ctx.lineWidth = 4;
   ctx.beginPath();
   ctx.moveTo(centerX, centerY);

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -126,7 +126,7 @@ function pointerUp(e) {
     stats.red++;
   }
   ctx.save();
-  ctx.strokeStyle = grade;
+  ctx.strokeStyle = grade === 'yellow' ? 'orange' : grade;
   ctx.beginPath();
   ctx.moveTo(startPos.x, startPos.y);
   ctx.lineTo(pos.x, pos.y);

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -31,7 +31,8 @@ function drawTarget() {
 
 function showPoints(pos, grade, callback) {
   ctx.save();
-  ctx.fillStyle = grade;
+  const color = grade === 'yellow' ? 'orange' : grade;
+  ctx.fillStyle = color;
   ctx.beginPath();
   ctx.arc(pos.x, pos.y, 5, 0, Math.PI * 2);
   ctx.fill();

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -31,7 +31,8 @@ function drawTarget() {
 
 function showPoints(pos, grade, callback) {
   ctx.save();
-  ctx.fillStyle = grade;
+  const color = grade === 'yellow' ? 'orange' : grade;
+  ctx.fillStyle = color;
   ctx.beginPath();
   ctx.arc(pos.x, pos.y, 5, 0, Math.PI * 2);
   ctx.fill();

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -31,7 +31,8 @@ function drawTarget() {
 
 function showPoints(pos, grade, callback) {
   ctx.save();
-  ctx.fillStyle = grade;
+  const color = grade === 'yellow' ? 'orange' : grade;
+  ctx.fillStyle = color;
   ctx.beginPath();
   ctx.arc(pos.x, pos.y, 5, 0, Math.PI * 2);
   ctx.fill();

--- a/style.css
+++ b/style.css
@@ -151,7 +151,7 @@ h2, h1 { margin: 10px 0; }
 
 .angle-option.close .box::after {
   content: '!';
-  color: gold;
+  color: orange;
   position: absolute;
   left: 3px;
   top: -3px;


### PR DESCRIPTION
## Summary
- Use orange for mid-range grade visuals in drawing evaluation
- Display "close" angle indicators in orange
- Render yellow-grade feedback in orange across drills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa7fc882483258d5978a1d6a1036a