### PR TITLE
Clear visual aids during inch drill grading

### DIFF
--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -129,6 +129,10 @@ function pointerUp(e) {
   } else {
     stats.red++;
   }
+
+  // Remove the arrow and the initially drawn line before displaying the grade
+  clearCanvas(ctx);
+
   ctx.save();
   ctx.strokeStyle = grade === 'yellow' ? 'orange' : grade;
   ctx.beginPath();


### PR DESCRIPTION
## Summary
- Clear canvas before grading in inch drill to remove arrow and initial line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fad665b988325ba681a765efec0f3