### PR TITLE
Disable accidental selection on canvas and buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,9 @@ html, body {
   padding: 0;
   font-family: sans-serif;
   background-color: #f0f0f0;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   user-select: none;
   min-height: 100%;
 }
@@ -31,6 +34,11 @@ canvas {
   width: min(90vmin, 500px);
   height: min(90vmin, 500px);
   touch-action: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .play-area {
@@ -120,6 +128,11 @@ button {
   padding: 8px 16px;
   font-size: 14px;
   cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
 h2, h1 { margin: 10px 0; }
 


### PR DESCRIPTION
## Summary
- prevent unwanted text selection across app by adding vendor-prefixed user-select rules
- remove tap highlight on canvas and buttons so they no longer show blue selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07615346083258cc1f2043260b19e