### PR TITLE
Add dexterity point drill for hand-eye coordination

### DIFF
--- a/dexterity.html
+++ b/dexterity.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dexterity Drills - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="menu-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Dexterity Drills</h2>
+    <div class="controls">
+      <button id="pointDrillBtn">Point Drill</button>
+    </div>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="dexterity.js"></script>
+</body>
+</html>

--- a/dexterity.js
+++ b/dexterity.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('pointDrillBtn')?.addEventListener('click', () => {
+    window.location.href = 'dexterity_point_drill.html';
+  });
+});

--- a/dexterity_point_drill.html
+++ b/dexterity_point_drill.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dexterity Point Drill - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Dexterity Point Drill</h2>
+    <button id="startBtn">Start</button>
+    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <p class="score" id="result"></p>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="dexterity_point_drill.js"></script>
+</body>
+</html>

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -1,0 +1,75 @@
+import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+
+let canvas, ctx, startBtn, result;
+let playing = false;
+let targets = [];
+let score = 0;
+let gameTimer = null;
+
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+function randomTarget() {
+  const margin = 20;
+  return {
+    x: Math.random() * (canvas.width - 2 * margin) + margin,
+    y: Math.random() * (canvas.height - 2 * margin) + margin
+  };
+}
+
+function drawTargets() {
+  clearCanvas(ctx);
+  ctx.fillStyle = 'black';
+  targets.forEach(t => {
+    ctx.beginPath();
+    ctx.arc(t.x, t.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function startGame() {
+  audioCtx.resume();
+  playing = true;
+  score = 0;
+  result.textContent = '';
+  startBtn.disabled = true;
+  targets = [randomTarget(), randomTarget()];
+  drawTargets();
+  gameTimer = setTimeout(endGame, 60000);
+}
+
+function endGame() {
+  if (!playing) return;
+  playing = false;
+  clearTimeout(gameTimer);
+  clearCanvas(ctx);
+  result.textContent = `Score: ${score}`;
+  startBtn.disabled = false;
+}
+
+function pointerDown(e) {
+  if (!playing) return;
+  const pos = getCanvasPos(canvas, e);
+  for (let i = 0; i < targets.length; i++) {
+    const t = targets[i];
+    const d = Math.hypot(pos.x - t.x, pos.y - t.y);
+    if (d <= 5) {
+      score++;
+      playSound(audioCtx, 'green');
+      targets[i] = randomTarget();
+      drawTargets();
+      return;
+    }
+  }
+  playSound(audioCtx, 'red');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+
+  canvas.addEventListener('pointerdown', pointerDown);
+  startBtn.addEventListener('click', startGame);
+});

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Memory Shape Drawing Game</h1>
     <button id="practiceBtn">Practice</button>
+    <button id="dexterityBtn">Dexterity</button>
     <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>
   </div>

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('practiceBtn')?.addEventListener('click', () => {
     window.location.href = 'practice.html';
   });
+  document.getElementById('dexterityBtn')?.addEventListener('click', () => {
+    window.location.href = 'dexterity.html';
+  });
   document.getElementById('scenariosBtn')?.addEventListener('click', () => {
     window.location.href = 'scenarios.html';
   });


### PR DESCRIPTION
## Summary
- Add new "Dexterity" section and point drill accessible from main menu
- Implement dexterity point drill with two simultaneous targets and audio-only feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07a9b6d9c8325b4afb8a78e2169e7