### PR TITLE
Add straight line tracing drill

### DIFF
--- a/dexterity.html
+++ b/dexterity.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Dexterity Drills - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="menu-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Dexterity Drills</h2>
+    <div class="controls">
+      <label>Drill:
+        <select id="drillSelect">
+          <option value="point_drill_01.html">Point Drill</option>
+          <option value="line_drill.html">Straight Line Drill</option>
+        </select>
+      </label>
+      <button id="startDrillBtn">Start</button>
+    </div>
+  </div>
+  <script src="back.js"></script>
+  <script src="dexterity.js"></script>
+</body>
+</html>

--- a/dexterity.js
+++ b/dexterity.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('startDrillBtn')?.addEventListener('click', () => {
+    const select = document.getElementById('drillSelect');
+    if (select && select.value) {
+      window.location.href = select.value;
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Memory Shape Drawing Game</h1>
     <button id="practiceBtn">Practice</button>
+    <button id="dexterityBtn">Dexterity</button>
     <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>
   </div>

--- a/index.js
+++ b/index.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('practiceBtn')?.addEventListener('click', () => {
     window.location.href = 'practice.html';
   });
+  document.getElementById('dexterityBtn')?.addEventListener('click', () => {
+    window.location.href = 'dexterity.html';
+  });
   document.getElementById('scenariosBtn')?.addEventListener('click', () => {
     window.location.href = 'scenarios.html';
   });

--- a/line_drill.html
+++ b/line_drill.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Straight Line Drill - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Straight Line Drill</h2>
+    <button id="startBtn">Start</button>
+    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <p class="score" id="result"></p>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="line_drill.js"></script>
+</body>
+</html>

--- a/line_drill.js
+++ b/line_drill.js
@@ -1,0 +1,123 @@
+import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+
+let canvas, ctx, startBtn, result;
+let playing = false;
+let drawing = false;
+let currentLine = null;
+let path = [];
+let score = 0;
+let gameTimer = null;
+
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const TOLERANCE = 5;
+
+function drawLine() {
+  const { x1, y1, x2, y2 } = currentLine;
+  clearCanvas(ctx);
+  ctx.strokeStyle = 'black';
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+}
+
+function newLine() {
+  const margin = 40;
+  const length = Math.random() * 200 + 50;
+  const angle = Math.random() * Math.PI * 2;
+  const x1 = Math.random() * (canvas.width - 2 * margin) + margin;
+  const y1 = Math.random() * (canvas.height - 2 * margin) + margin;
+  const x2 = x1 + Math.cos(angle) * length;
+  const y2 = y1 + Math.sin(angle) * length;
+  currentLine = { x1, y1, x2, y2 };
+  drawLine();
+}
+
+function startGame() {
+  audioCtx.resume();
+  score = 0;
+  playing = true;
+  result.textContent = '';
+  startBtn.disabled = true;
+  gameTimer = setTimeout(endGame, 60000);
+  newLine();
+}
+
+function endGame() {
+  if (!playing) return;
+  playing = false;
+  clearTimeout(gameTimer);
+  clearCanvas(ctx);
+  result.textContent = `Lines correct: ${score}`;
+  startBtn.disabled = false;
+}
+
+function pointerDown(e) {
+  if (!playing) return;
+  drawing = true;
+  path = [getCanvasPos(canvas, e)];
+  ctx.beginPath();
+  ctx.moveTo(path[0].x, path[0].y);
+}
+
+function pointerMove(e) {
+  if (!drawing) return;
+  const pos = getCanvasPos(canvas, e);
+  path.push(pos);
+  ctx.lineTo(pos.x, pos.y);
+  ctx.strokeStyle = 'black';
+  ctx.stroke();
+}
+
+function pointerUp(e) {
+  if (!drawing) return;
+  drawing = false;
+  const pos = getCanvasPos(canvas, e);
+  path.push(pos);
+  if (!playing) {
+    clearCanvas(ctx);
+    return;
+  }
+  if (checkPath()) {
+    score++;
+    playSound(audioCtx, 'green');
+    newLine();
+  } else {
+    playSound(audioCtx, 'red');
+    drawLine();
+  }
+}
+
+function checkPath() {
+  const { x1, y1, x2, y2 } = currentLine;
+  const vx = x2 - x1;
+  const vy = y2 - y1;
+  const len = Math.hypot(vx, vy);
+  const ux = vx / len;
+  const uy = vy / len;
+  let minS = Infinity;
+  let maxS = -Infinity;
+  for (const p of path) {
+    const sx = p.x - x1;
+    const sy = p.y - y1;
+    const s = sx * ux + sy * uy;
+    const dist = Math.abs(sx * uy - sy * ux);
+    if (dist > TOLERANCE) return false;
+    if (s < minS) minS = s;
+    if (s > maxS) maxS = s;
+  }
+  return minS <= TOLERANCE && maxS >= len - TOLERANCE;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+
+  canvas.addEventListener('pointerdown', pointerDown);
+  canvas.addEventListener('pointermove', pointerMove);
+  canvas.addEventListener('pointerup', pointerUp);
+  startBtn.addEventListener('click', startGame);
+});


### PR DESCRIPTION
## Summary
- add straight line drill page for freehand tracing practice
- implement line tracing logic with scoring and audio feedback
- add drill dropdown to dexterity menu to launch point or line drills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07bcae1b8832590991e113196aafb