### PR TITLE
Consolidate practice and scenarios into Memorization menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is a small browser game where you try to memorize and recreate rand
 ## Running the Game
 
 1. Open `index.html` in any modern web browser. No build step or server is required—just open the file directly.
-2. The menu provides buttons for **Practice**, **Scenarios**, and **About**. Practice is the main gameplay mode.
+2. The menu provides buttons for **Memorization**, **Dexterity**, and **About**. Memorization contains both Practice and Scenario modes.
 
 ## Basic Controls
 

--- a/index.html
+++ b/index.html
@@ -10,9 +10,8 @@
   <!-- MENU SCREEN -->
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Memory Shape Drawing Game</h1>
-    <button id="practiceBtn">Practice</button>
+    <button id="memorizationBtn">Memorization</button>
     <button id="dexterityBtn">Dexterity</button>
-    <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>
   </div>
   <script src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -5,14 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const freeEl = document.getElementById('freehandBest');
   if (p2pEl) p2pEl.textContent = p2pBest ? `${parseFloat(p2pBest).toFixed(1)} px` : 'N/A';
   if (freeEl) freeEl.textContent = freehandBest ? `${parseFloat(freehandBest).toFixed(1)} px` : 'N/A';
-  document.getElementById('practiceBtn')?.addEventListener('click', () => {
-    window.location.href = 'practice.html';
+  document.getElementById('memorizationBtn')?.addEventListener('click', () => {
+    window.location.href = 'memorization.html';
   });
   document.getElementById('dexterityBtn')?.addEventListener('click', () => {
     window.location.href = 'dexterity.html';
-  });
-  document.getElementById('scenariosBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
   });
   document.getElementById('aboutBtn')?.addEventListener('click', () => {
     window.location.href = 'about.html';

--- a/memorization.html
+++ b/memorization.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Memorization - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="menu-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Memorization</h2>
+    <div class="controls">
+      <button id="practiceBtn">Practice</button>
+      <button id="scenariosBtn">Scenarios</button>
+    </div>
+  </div>
+  <script src="back.js"></script>
+  <script src="memorization.js"></script>
+</body>
+</html>
+

--- a/memorization.js
+++ b/memorization.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('practiceBtn')?.addEventListener('click', () => {
+    window.location.href = 'practice.html';
+  });
+  document.getElementById('scenariosBtn')?.addEventListener('click', () => {
+    window.location.href = 'scenarios.html';
+  });
+});
+


### PR DESCRIPTION
## Summary
- Replace separate Practice and Scenarios buttons with unified **Memorization** option on the main menu
- Add new Memorization sub-menu linking to Practice and Scenarios
- Update navigation script and documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a214b8588325aea51133b36ac32e