### PR TITLE
Use scroll menus for exercise selection

### DIFF
--- a/dexterity.html
+++ b/dexterity.html
@@ -10,8 +10,14 @@
   <div class="menu-screen">
     <button id="backBtn">← Back</button>
     <h2>Dexterity Drills</h2>
-    <div class="controls">
-      <button id="pointDrillBtn">Point Drill</button>
+    <div id="exerciseList" class="exercise-list">
+      <div class="exercise-item" data-link="dexterity_point_drill.html">
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Point Drill</h3>
+          <p>Improve pointer accuracy with rapid taps.</p>
+        </div>
+      </div>
     </div>
   </div>
   <script src="back.js"></script>

--- a/dexterity.js
+++ b/dexterity.js
@@ -1,5 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('pointDrillBtn')?.addEventListener('click', () => {
-    window.location.href = 'dexterity_point_drill.html';
+  document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
+    item.addEventListener('click', () => {
+      window.location.href = item.dataset.link;
+    });
   });
 });

--- a/memorization.html
+++ b/memorization.html
@@ -10,13 +10,24 @@
   <div class="menu-screen">
     <button id="backBtn">← Back</button>
     <h2>Memorization</h2>
-    <div class="controls">
-      <button id="practiceBtn">Practice</button>
-      <button id="scenariosBtn">Scenarios</button>
+    <div id="exerciseList" class="exercise-list">
+      <div class="exercise-item" data-link="practice.html">
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Practice</h3>
+          <p>Train with custom shapes and settings.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="scenarios.html">
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Scenarios</h3>
+          <p>Play predefined scenario challenges.</p>
+        </div>
+      </div>
     </div>
   </div>
   <script src="back.js"></script>
   <script src="memorization.js"></script>
 </body>
 </html>
-

--- a/memorization.js
+++ b/memorization.js
@@ -1,9 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('practiceBtn')?.addEventListener('click', () => {
-    window.location.href = 'practice.html';
-  });
-  document.getElementById('scenariosBtn')?.addEventListener('click', () => {
-    window.location.href = 'scenarios.html';
+  document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
+    item.addEventListener('click', () => {
+      window.location.href = item.dataset.link;
+    });
   });
 });
-

--- a/scenarios.html
+++ b/scenarios.html
@@ -10,13 +10,9 @@
   <div class="menu-screen">
     <button id="backBtn">← Back</button>
     <h2>Scenarios</h2>
+    <div id="scenarioList" class="exercise-list"></div>
     <div class="controls">
-      <label>Choose Scenario:
-        <select id="scenarioList"></select>
-      </label>
-    </div>
-    <div class="controls">
-      <button id="playBtn">Play Scenario</button>
+      <button id="playBtn" disabled>Play Scenario</button>
     </div>
   </div>
   <script src="back.js"></script>

--- a/scenarios.js
+++ b/scenarios.js
@@ -28,15 +28,33 @@ function getScenarioNames() {
   return [...Object.keys(builtInScenarios), ...Object.keys(getSavedScenarios())];
 }
 
+let selectedScenario = null;
+
 function loadScenarioList() {
   const list = document.getElementById('scenarioList');
   if (!list) return;
   list.innerHTML = '';
   getScenarioNames().forEach(name => {
-    const opt = document.createElement('option');
-    opt.value = name;
-    opt.textContent = name;
-    list.appendChild(opt);
+    const item = document.createElement('div');
+    item.className = 'exercise-item';
+    const img = document.createElement('img');
+    img.className = 'exercise-gif';
+    img.alt = '';
+    const info = document.createElement('div');
+    info.className = 'exercise-info';
+    const title = document.createElement('h3');
+    title.textContent = name;
+    info.appendChild(title);
+    item.appendChild(img);
+    item.appendChild(info);
+    item.addEventListener('click', () => {
+      selectedScenario = name;
+      list.querySelectorAll('.exercise-item').forEach(el => el.classList.remove('selected'));
+      item.classList.add('selected');
+      const playBtn = document.getElementById('playBtn');
+      if (playBtn) playBtn.disabled = false;
+    });
+    list.appendChild(item);
   });
 }
 
@@ -45,9 +63,8 @@ export function getScenarioUrl(name) {
 }
 
 export function playSelectedScenario() {
-  const name = document.getElementById('scenarioList')?.value;
-  if (!name) return;
-  window.location.assign(getScenarioUrl(name));
+  if (!selectedScenario) return;
+  window.location.assign(getScenarioUrl(selectedScenario));
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -196,3 +196,56 @@ h2, h1 { margin: 10px 0; }
   top: -3px;
   font-size: 18px;
 }
+/* Exercise list styles */
+.exercise-list {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 500px;
+  max-height: 60vh;
+  overflow-y: auto;
+  gap: 10px;
+}
+
+.exercise-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.exercise-item:hover {
+  background-color: #f9f9f9;
+}
+
+.exercise-item.selected {
+  border-color: #2196F3;
+  background-color: #e3f2fd;
+}
+
+.exercise-item img.exercise-gif {
+  width: 60px;
+  height: 60px;
+  margin-right: 10px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+.exercise-item .exercise-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.exercise-item h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.exercise-item p {
+  margin: 4px 0 0;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- Replace exercise selection buttons with scrollable rectangular menu items
- Style exercises with full-width bars that can display titles, descriptions, and future gifs
- Convert scenario dropdown to selectable list with highlighting and enable Play button on selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0b064822c8325a89aea5477a4aca4