### PR TITLE
Fix missing scenario exercises in memorization tab

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import { scenarioUrls } from '../scenarios.js';
+
+describe('memorization page', () => {
+  test('lists built-in scenarios when DOM already loaded', async () => {
+    document.body.innerHTML = `
+      <div id="exerciseList" class="exercise-list">
+        <div class="exercise-item" data-link="shape_trainer.html">
+          <img class="exercise-gif" alt="" />
+          <div class="exercise-info">
+            <h3>Shape Trainer</h3>
+            <p>Train with custom shapes and settings.</p>
+          </div>
+        </div>
+      </div>
+    `;
+
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    await import('../memorization.js');
+
+    const items = Array.from(document.querySelectorAll('.exercise-item[data-link] h3'))
+      .map(el => el.textContent);
+    expect(items).toEqual(['Shape Trainer', ...Object.keys(scenarioUrls)]);
+  });
+});

--- a/memorization.js
+++ b/memorization.js
@@ -1,6 +1,6 @@
 import { scenarioUrls, getScenarioUrl } from './scenarios.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
   const list = document.getElementById('exerciseList');
   const saved = JSON.parse(localStorage.getItem('scenarios') || '{}');
   const scenarios = [...Object.keys(scenarioUrls), ...Object.keys(saved)];
@@ -26,4 +26,10 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = item.dataset.link;
     });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}


### PR DESCRIPTION
## Summary
- Make memorization page initialize immediately when DOM is already loaded to populate built-in scenarios
- Add regression test to ensure memorization lists scenario exercises

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d0aaecc4832592d564e30104eac0