### PR TITLE
Add descriptions to Memorization drills

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { scenarioUrls } from '../scenarios.js';
+import { scenarioUrls, scenarioDescriptions } from '../scenarios.js';
 
 describe('memorization page', () => {
   test('lists built-in scenarios when DOM already loaded', async () => {
@@ -18,8 +18,17 @@ describe('memorization page', () => {
     Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
     await import('../memorization.js');
 
-    const items = Array.from(document.querySelectorAll('.exercise-item[data-link] h3'))
-      .map(el => el.textContent);
-    expect(items).toEqual(['Shape Trainer', ...Object.keys(scenarioUrls)]);
+    const items = Array.from(document.querySelectorAll('.exercise-item[data-link]'))
+      .map(item => ({
+        title: item.querySelector('h3')?.textContent,
+        desc: item.querySelector('p')?.textContent
+      }));
+    expect(items).toEqual([
+      { title: 'Shape Trainer', desc: 'Train with custom shapes and settings.' },
+      ...Object.keys(scenarioUrls).map(name => ({
+        title: name,
+        desc: scenarioDescriptions[name]
+      }))
+    ]);
   });
 });

--- a/memorization.js
+++ b/memorization.js
@@ -1,4 +1,4 @@
-import { scenarioUrls, getScenarioUrl } from './scenarios.js';
+import { scenarioUrls, getScenarioUrl, scenarioDescriptions } from './scenarios.js';
 
 function init() {
   const list = document.getElementById('exerciseList');
@@ -16,6 +16,9 @@ function init() {
     const title = document.createElement('h3');
     title.textContent = name;
     info.appendChild(title);
+    const desc = document.createElement('p');
+    desc.textContent = scenarioDescriptions[name] || 'User-created scenario.';
+    info.appendChild(desc);
     item.appendChild(img);
     item.appendChild(info);
     list.appendChild(item);

--- a/scenarios.js
+++ b/scenarios.js
@@ -7,6 +7,15 @@ export const scenarioUrls = {
   "Point Drill 0.1 sec Look": 'point_drill_01.html'
 };
 
+export const scenarioDescriptions = {
+  "Angle Challenge (5\u00B0 increments)": 'Guess randomly oriented angles in 5\u00B0 steps.',
+  "Angle Challenge (10\u00B0 increments)": 'Guess randomly oriented angles in 10\u00B0 steps.',
+  "Inch Drill": 'Draw a 1-inch line from a given starting arrow.',
+  "Point Drill 0.5 sec Look": 'Memorize a point after a 0.5 second preview and tap its location.',
+  "Point Drill 0.25 sec Look": 'Memorize a point after a 0.25 second preview and tap its location.',
+  "Point Drill 0.1 sec Look": 'Memorize a point after a 0.1 second preview and tap its location.'
+};
+
 const builtInScenarios = Object.fromEntries(
   Object.keys(scenarioUrls).map(name => [name, { special: true }])
 );


### PR DESCRIPTION
## Summary
- Add descriptive text for built-in memorization scenarios
- Render scenario descriptions on the Memorization page
- Expand tests to verify displayed titles and descriptions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d446225083259807c9ad0e52c2fe