### PR TITLE
Enable point placement during grading tone

### DIFF
--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -10,6 +10,7 @@ let gameTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const RESULT_DISPLAY_TIME = 100;
 
 function drawTarget() {
   const margin = 20;
@@ -44,7 +45,7 @@ function showPoints(pos, grade, callback) {
   setTimeout(() => {
     clearCanvas(ctx);
     callback();
-  }, 300);
+  }, RESULT_DISPLAY_TIME);
 }
 
 function pointerDown(e) {

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -10,6 +10,7 @@ let gameTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const RESULT_DISPLAY_TIME = 100;
 
 function drawTarget() {
   const margin = 20;
@@ -44,7 +45,7 @@ function showPoints(pos, grade, callback) {
   setTimeout(() => {
     clearCanvas(ctx);
     callback();
-  }, 300);
+  }, RESULT_DISPLAY_TIME);
 }
 
 function pointerDown(e) {

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -10,6 +10,7 @@ let gameTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const RESULT_DISPLAY_TIME = 100;
 
 function drawTarget() {
   const margin = 20;
@@ -44,7 +45,7 @@ function showPoints(pos, grade, callback) {
   setTimeout(() => {
     clearCanvas(ctx);
     callback();
-  }, 300);
+  }, RESULT_DISPLAY_TIME);
 }
 
 function pointerDown(e) {


### PR DESCRIPTION
## Summary
- shorten result display delay in point drills so new targets appear immediately
- allow placing new points while previous grading tone is still playing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e0b69dd483258ffe010c7970d196