### PR TITLE
Allow clicks during point drill grading tone

### DIFF
--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -54,13 +54,16 @@ function pointerDown(e) {
     const d = Math.hypot(pos.x - t.x, pos.y - t.y);
     if (d <= 5) {
       score++;
-      playSound(audioCtx, 'green');
+      // Play the grading tone asynchronously so that additional
+      // pointer events can be processed while the sound is playing.
+      setTimeout(() => playSound(audioCtx, 'green'), 0);
       targets[i] = randomTarget();
       drawTargets();
       return;
     }
   }
-  playSound(audioCtx, 'red');
+  // Likewise, play the miss tone without blocking pointer input.
+  setTimeout(() => playSound(audioCtx, 'red'), 0);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- avoid blocking pointer input during audio playback in dexterity point drill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0e2a600f883258ad18e73829dc09f