### PR TITLE
Improve dexterity line drill timing and line width

### DIFF
--- a/dexterity_line_drill.html
+++ b/dexterity_line_drill.html
@@ -13,6 +13,7 @@
     <button id="startBtn">Start</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>
     <p class="score" id="result"></p>
+    <p class="score" id="timeDisplay"></p>
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_line_drill.js"></script>


### PR DESCRIPTION
## Summary
- Align dexterity line drill line width with other scenarios
- Display live draw timing and color it green or red based on success
- Render player's line in real time and color segments green when within tolerance and red otherwise

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ea38d63483259940e11725d66adf