### PR TITLE
Allow recovering from off-line starts in line drill

### DIFF
--- a/dexterity_line_drill.js
+++ b/dexterity_line_drill.js
@@ -112,20 +112,33 @@ function pointerMove(e) {
   let normT = 0;
   if (activeTarget !== null) {
     ({ dist, t: normT } = projectPointToSegment(pos, targets[activeTarget]));
+  } else {
+    for (let i = 0; i < targets.length; i++) {
+      const proj = projectPointToSegment(pos, targets[i]);
+      if (proj.dist <= tolerance) {
+        activeTarget = i;
+        dist = proj.dist;
+        normT = proj.t;
+        break;
+      }
+    }
   }
 
   ctx.beginPath();
   ctx.moveTo(lastPos.x, lastPos.y);
   ctx.lineTo(pos.x, pos.y);
   ctx.lineWidth = 2;
-  totalSegments++;
-  if (dist <= tolerance) {
+  if (dist <= tolerance && activeTarget !== null) {
     ctx.strokeStyle = 'green';
     minT = Math.min(minT, normT);
     maxT = Math.max(maxT, normT);
+    totalSegments++;
   } else {
     ctx.strokeStyle = 'red';
-    offLineSegments++;
+    if (activeTarget !== null) {
+      offLineSegments++;
+      totalSegments++;
+    }
   }
   ctx.stroke();
   lastPos = pos;


### PR DESCRIPTION
## Summary
- allow pointer to start off-line and begin scoring once it touches a line
- only count segments after the target line is engaged to prevent automatic failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20acfc7488325938da2096ddbc11c