### PR TITLE
Add difficulty labels to drill menus

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -5,7 +5,8 @@ describe('memorization page', () => {
   test('lists built-in scenarios when DOM already loaded', async () => {
     document.body.innerHTML = `
       <div id="exerciseList" class="exercise-list">
-        <div class="exercise-item" data-link="shape_trainer.html">
+        <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
           <img class="exercise-gif" alt="" />
           <div class="exercise-info">
             <h3>Shape Trainer</h3>

--- a/dexterity.html
+++ b/dexterity.html
@@ -11,28 +11,32 @@
     <button id="backBtn">← Back</button>
     <h2>Dexterity Drills</h2>
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="dexterity_point_drill_large.html">
+      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner">
+        <span class="difficulty-label difficulty-beginner">Beginner</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Large Points</h3>
           <p>Point drill with larger targets for easier accuracy.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_point_drill.html">
+      <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept">
+        <span class="difficulty-label difficulty-adept">Adept</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Medium Points</h3>
           <p>Improve pointer accuracy with rapid taps.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_point_drill_small.html">
+      <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert">
+        <span class="difficulty-label difficulty-expert">Expert</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Small Points</h3>
           <p>Point drill with smaller targets for higher precision.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_line_drill.html">
+      <div class="exercise-item" data-link="dexterity_line_drill.html" data-difficulty="Adept">
+        <span class="difficulty-label difficulty-adept">Adept</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Line Drill</h3>

--- a/memorization.html
+++ b/memorization.html
@@ -11,7 +11,8 @@
     <button id="backBtn">← Back</button>
     <h2>Memorization</h2>
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="shape_trainer.html">
+      <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
+        <span class="difficulty-label difficulty-beginner">Beginner</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Shape Trainer</h3>

--- a/memorization.js
+++ b/memorization.js
@@ -1,4 +1,4 @@
-import { scenarioUrls, getScenarioUrl, scenarioDescriptions } from './scenarios.js';
+import { scenarioUrls, getScenarioUrl, scenarioDescriptions, scenarioDifficulty } from './scenarios.js';
 
 function init() {
   const list = document.getElementById('exerciseList');
@@ -8,6 +8,14 @@ function init() {
     const item = document.createElement('div');
     item.className = 'exercise-item';
     item.dataset.link = getScenarioUrl(name);
+    const diff = scenarioDifficulty[name];
+    if (diff) {
+      item.dataset.difficulty = diff;
+      const badge = document.createElement('span');
+      badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
+      badge.textContent = diff;
+      item.appendChild(badge);
+    }
     const img = document.createElement('img');
     img.className = 'exercise-gif';
     img.alt = '';

--- a/scenarios.js
+++ b/scenarios.js
@@ -16,6 +16,15 @@ export const scenarioDescriptions = {
   "Point Drill 0.1 sec Look": 'Memorize a point after a 0.1 second preview and tap its location.'
 };
 
+export const scenarioDifficulty = {
+  "Angle Challenge (5\u00B0 increments)": 'Adept',
+  "Angle Challenge (10\u00B0 increments)": 'Beginner',
+  "Inch Drill": 'Beginner',
+  "Point Drill 0.5 sec Look": 'Beginner',
+  "Point Drill 0.25 sec Look": 'Adept',
+  "Point Drill 0.1 sec Look": 'Expert'
+};
+
 const builtInScenarios = Object.fromEntries(
   Object.keys(scenarioUrls).map(name => [name, { special: true }])
 );
@@ -46,6 +55,14 @@ function loadScenarioList() {
   getScenarioNames().forEach(name => {
     const item = document.createElement('div');
     item.className = 'exercise-item';
+    const diff = scenarioDifficulty[name];
+    if (diff) {
+      item.dataset.difficulty = diff;
+      const badge = document.createElement('span');
+      badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
+      badge.textContent = diff;
+      item.appendChild(badge);
+    }
     const img = document.createElement('img');
     img.className = 'exercise-gif';
     img.alt = '';

--- a/style.css
+++ b/style.css
@@ -273,6 +273,7 @@ h2, h1 { margin: 10px 0; }
   border-radius: 6px;
   padding: 10px;
   cursor: pointer;
+  position: relative;
 }
 
 .exercise-item:hover {
@@ -305,4 +306,26 @@ h2, h1 { margin: 10px 0; }
 .exercise-item p {
   margin: 4px 0 0;
   font-size: 14px;
+}
+
+.difficulty-label {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-size: 12px;
+  color: #fff;
+}
+
+.difficulty-beginner {
+  background-color: #4CAF50;
+}
+
+.difficulty-adept {
+  background-color: #FF9800;
+}
+
+.difficulty-expert {
+  background-color: #F44336;
 }


### PR DESCRIPTION
## Summary
- Display beginner/adept/expert badges in the top-right of each drill menu item
- Add difficulty metadata for built-in scenarios and render badges dynamically
- Style difficulty tags with colored rounded backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2136336f88325afd75913ce1f138d