### PR TITLE
Fix difficulty label rendering on dexterity page

### DIFF
--- a/dexterity.html
+++ b/dexterity.html
@@ -35,16 +35,16 @@
           <p>Point drill with smaller targets for higher precision.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_line_drill.html" data-difficulty="Adept">
-        <span class="difficulty-label difficulty-adept">Adept</span>
-      <div class="exercise-item" data-link="dexterity_thick_lines.html">
+      <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner">
+        <span class="difficulty-label difficulty-beginner">Beginner</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Thick Lines</h3>
           <p>Trace thicker lines for an easier challenge.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_thin_lines.html">
+      <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept">
+        <span class="difficulty-label difficulty-adept">Adept</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Thin Lines</h3>


### PR DESCRIPTION
## Summary
- remove malformed line-drill entry that nested other items
- add difficulty badges for thick and thin line drills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21742c9488325bb62e91ba7b65e00