### PR TITLE
Enlarge menu buttons and drill cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,11 @@ html, body {
   align-items: center;
   justify-content: center;
 }
+#menuScreen button {
+  padding: 12px 24px;
+  font-size: 18px;
+  margin: 8px 0;
+}
 canvas {
   display: block;
   margin: 10px auto;
@@ -258,10 +263,10 @@ h2, h1 { margin: 10px 0; }
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 500px;
+  max-width: 600px;
   max-height: 60vh;
   overflow-y: auto;
-  gap: 10px;
+  gap: 15px;
 }
 
 .exercise-item {
@@ -271,7 +276,7 @@ h2, h1 { margin: 10px 0; }
   background: white;
   border: 1px solid #ccc;
   border-radius: 6px;
-  padding: 10px;
+  padding: 15px;
   cursor: pointer;
   position: relative;
 }
@@ -286,9 +291,9 @@ h2, h1 { margin: 10px 0; }
 }
 
 .exercise-item img.exercise-gif {
-  width: 60px;
-  height: 60px;
-  margin-right: 10px;
+  width: 80px;
+  height: 80px;
+  margin-right: 15px;
   object-fit: cover;
   border-radius: 4px;
 }
@@ -300,21 +305,21 @@ h2, h1 { margin: 10px 0; }
 
 .exercise-item h3 {
   margin: 0;
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .exercise-item p {
   margin: 4px 0 0;
-  font-size: 14px;
+  font-size: 16px;
 }
 
 .difficulty-label {
   position: absolute;
   top: 5px;
   right: 5px;
-  padding: 2px 6px;
-  border-radius: 8px;
-  font-size: 10px;
+  padding: 4px 8px;
+  border-radius: 10px;
+  font-size: 12px;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- Increase main menu button padding and font size for greater visibility
- Expand drill card layout with larger images, fonts, and spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a21e3758d08325b707aa4213692232