### PR TITLE
Expand drill card container for responsive layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -50,6 +50,8 @@ canvas {
   display: flex;
   align-items: flex-start;
   gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .play-area.reverse {
@@ -273,6 +275,7 @@ h2, h1 { margin: 10px 0; }
   display: flex;
   align-items: center;
   width: 100%;
+  box-sizing: border-box;
   background: white;
   border: 1px solid #ccc;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- Allow play area to wrap and center its contents so drill cards stay fully visible without horizontal scrolling
- Apply border-box sizing to drill selection cards to fit within the viewport on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a220f15b3c8325b7108f7bbd8cb848