### PR TITLE
Display high scores on exercise cards

### DIFF
--- a/dexterity.html
+++ b/dexterity.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Dexterity Drills</h2>
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
         <span class="difficulty-label difficulty-beginner">Beginner</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -19,7 +19,7 @@
           <p>Point drill with larger targets for easier accuracy.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept" data-score-key="dexterity_point_drill">
         <span class="difficulty-label difficulty-adept">Adept</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -27,7 +27,7 @@
           <p>Improve pointer accuracy with rapid taps.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert">
+      <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert" data-score-key="dexterity_point_drill_small">
         <span class="difficulty-label difficulty-expert">Expert</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -35,7 +35,7 @@
           <p>Point drill with smaller targets for higher precision.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
         <span class="difficulty-label difficulty-beginner">Beginner</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -43,7 +43,7 @@
           <p>Trace thicker lines for an easier challenge.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
         <span class="difficulty-label difficulty-adept">Adept</span>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">

--- a/dexterity.js
+++ b/dexterity.js
@@ -1,5 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
+    const info = item.querySelector('.exercise-info');
+    const key = item.dataset.scoreKey;
+    if (info && key) {
+      const val = localStorage.getItem(key) || 0;
+      const p = document.createElement('p');
+      p.className = 'high-score';
+      p.textContent = `High Score: ${val}`;
+      info.appendChild(p);
+    }
     item.addEventListener('click', () => {
       window.location.href = item.dataset.link;
     });

--- a/dexterity_point_drill.html
+++ b/dexterity_point_drill.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Medium Points</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500" data-radius="5" data-tolerance="5"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-radius="5" data-tolerance="5" data-score-key="dexterity_point_drill"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -7,6 +7,7 @@ let score = 0;
 let gameTimer = null;
 let targetRadius = 5;
 let gradingTolerance = 5;
+let scoreKey = 'dexterity_point_drill';
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -44,7 +45,12 @@ function endGame() {
   playing = false;
   clearTimeout(gameTimer);
   clearCanvas(ctx);
-  result.textContent = `Score: ${score}`;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Score: ${score} (Best: ${high})`;
   startBtn.disabled = false;
 }
 
@@ -76,6 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
   result = document.getElementById('result');
   targetRadius = Number(canvas.dataset.radius) || targetRadius;
   gradingTolerance = Number(canvas.dataset.tolerance) || targetRadius;
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/dexterity_point_drill_large.html
+++ b/dexterity_point_drill_large.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Large Points</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500" data-radius="10" data-tolerance="10"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-radius="10" data-tolerance="10" data-score-key="dexterity_point_drill_large"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/dexterity_point_drill_small.html
+++ b/dexterity_point_drill_small.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Small Points</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500" data-radius="3" data-tolerance="3"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-radius="3" data-tolerance="3" data-score-key="dexterity_point_drill_small"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/dexterity_thick_lines.html
+++ b/dexterity_thick_lines.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Thick Lines</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thick_lines"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -5,6 +5,7 @@ let playing = false;
 let targets = [];
 let score = 0;
 let gameTimer = null;
+let scoreKey = 'dexterity_thick_lines';
 
 let drawing = false;
 let activeTarget = null;
@@ -77,7 +78,12 @@ function endGame() {
   playing = false;
   clearTimeout(gameTimer);
   clearCanvas(ctx);
-  result.textContent = `Score: ${score}`;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Score: ${score} (Best: ${high})`;
   startBtn.disabled = false;
 }
 
@@ -185,6 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);
   canvas.addEventListener('pointermove', pointerMove);

--- a/dexterity_thin_lines.html
+++ b/dexterity_thin_lines.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Thin Lines</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thin_lines"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/dexterity_thin_lines.js
+++ b/dexterity_thin_lines.js
@@ -5,6 +5,7 @@ let playing = false;
 let targets = [];
 let score = 0;
 let gameTimer = null;
+let scoreKey = 'dexterity_thin_lines';
 
 let drawing = false;
 let activeTarget = null;
@@ -77,7 +78,12 @@ function endGame() {
   playing = false;
   clearTimeout(gameTimer);
   clearCanvas(ctx);
-  result.textContent = `Score: ${score}`;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Score: ${score} (Best: ${high})`;
   startBtn.disabled = false;
 }
 
@@ -185,6 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);
   canvas.addEventListener('pointermove', pointerMove);

--- a/memorization.js
+++ b/memorization.js
@@ -27,10 +27,28 @@ function init() {
     const desc = document.createElement('p');
     desc.textContent = scenarioDescriptions[name] || 'User-created scenario.';
     info.appendChild(desc);
+    const high = localStorage.getItem(`scenarioScore_${name}`) || 0;
+    const hs = document.createElement('p');
+    hs.className = 'high-score';
+    hs.textContent = `High Score: ${high}`;
+    info.appendChild(hs);
     item.appendChild(img);
     item.appendChild(info);
     list.appendChild(item);
   });
+
+  const trainer = document.querySelector('.exercise-item[data-link="shape_trainer.html"]');
+  if (trainer) {
+    const info = trainer.querySelector('.exercise-info');
+    const p2p = localStorage.getItem('p2pBest');
+    const free = localStorage.getItem('freehandBest');
+    const hs = document.createElement('p');
+    hs.className = 'high-score';
+    const p2pText = p2p ? `${parseFloat(p2p).toFixed(1)} px` : 'N/A';
+    const freeText = free ? `${parseFloat(free).toFixed(1)} px` : 'N/A';
+    hs.textContent = `Best - P2P: ${p2pText}, Freehand: ${freeText}`;
+    info.appendChild(hs);
+  }
 
   document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
     item.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -316,6 +316,12 @@ h2, h1 { margin: 10px 0; }
   font-size: 16px;
 }
 
+.exercise-item .high-score {
+  margin-top: 8px;
+  font-size: 14px;
+  color: #555;
+}
+
 .difficulty-label {
   position: absolute;
   top: 5px;


### PR DESCRIPTION
## Summary
- show saved high scores under each exercise card
- persist and display high scores for dexterity drills
- style high score text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46bf1c0248325b1abbe0993091219