### PR TITLE
Extend point drill feedback duration

### DIFF
--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -10,7 +10,7 @@ let gameTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-const RESULT_DISPLAY_TIME = 100;
+const RESULT_DISPLAY_TIME = 300;
 
 function drawTarget() {
   const margin = 20;

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -10,7 +10,7 @@ let gameTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-const RESULT_DISPLAY_TIME = 100;
+const RESULT_DISPLAY_TIME = 300;
 
 function drawTarget() {
   const margin = 20;

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -10,7 +10,7 @@ let gameTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-const RESULT_DISPLAY_TIME = 100;
+const RESULT_DISPLAY_TIME = 300;
 
 function drawTarget() {
   const margin = 20;


### PR DESCRIPTION
## Summary
- Keep point drill hit/miss markers on screen longer by increasing result display time to 300ms across all memorization point drills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a666a22b9c8325ace323072bcc0aeb