### PR TITLE
Add triangles memorization drill card

### DIFF
--- a/memorization.html
+++ b/memorization.html
@@ -19,6 +19,14 @@
           <p>Train with custom shapes and settings.</p>
         </div>
       </div>
+      <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
+        <span class="difficulty-label difficulty-beginner">Beginner</span>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Triangles</h3>
+          <p>Memorize triangle vertices.</p>
+        </div>
+      </div>
     </div>
   </div>
   <script src="back.js"></script>

--- a/memorization.js
+++ b/memorization.js
@@ -5,36 +5,60 @@ function init() {
   const saved = JSON.parse(localStorage.getItem('scenarios') || '{}');
   const scenarios = [...Object.keys(scenarioUrls), ...Object.keys(saved)];
   scenarios.forEach(name => {
-    const item = document.createElement('div');
-    item.className = 'exercise-item';
-    item.dataset.link = getScenarioUrl(name);
     const diff = scenarioDifficulty[name];
-    if (diff) {
-      item.dataset.difficulty = diff;
-      const badge = document.createElement('span');
-      badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
-      badge.textContent = diff;
-      item.appendChild(badge);
-    }
-    const img = document.createElement('img');
-    img.className = 'exercise-gif';
-    img.alt = '';
-    const info = document.createElement('div');
-    info.className = 'exercise-info';
-    const title = document.createElement('h3');
-    title.textContent = name;
-    info.appendChild(title);
-    const desc = document.createElement('p');
-    desc.textContent = scenarioDescriptions[name] || 'User-created scenario.';
-    info.appendChild(desc);
     const high = localStorage.getItem(`scenarioScore_${name}`) || 0;
-    const hs = document.createElement('p');
-    hs.className = 'high-score';
-    hs.textContent = `High Score: ${high}`;
-    info.appendChild(hs);
-    item.appendChild(img);
-    item.appendChild(info);
-    list.appendChild(item);
+    const existing = Array.from(list.querySelectorAll('.exercise-item'))
+      .find(item => item.querySelector('h3')?.textContent === name);
+    if (existing) {
+      existing.dataset.link = getScenarioUrl(name);
+      if (diff) {
+        existing.dataset.difficulty = diff;
+        let badge = existing.querySelector('.difficulty-label');
+        if (!badge) {
+          badge = document.createElement('span');
+          existing.insertBefore(badge, existing.firstChild);
+        }
+        badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
+        badge.textContent = diff;
+      }
+      const info = existing.querySelector('.exercise-info');
+      let hs = existing.querySelector('.high-score');
+      if (!hs) {
+        hs = document.createElement('p');
+        hs.className = 'high-score';
+        info.appendChild(hs);
+      }
+      hs.textContent = `High Score: ${high}`;
+    } else {
+      const item = document.createElement('div');
+      item.className = 'exercise-item';
+      item.dataset.link = getScenarioUrl(name);
+      if (diff) {
+        item.dataset.difficulty = diff;
+        const badge = document.createElement('span');
+        badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
+        badge.textContent = diff;
+        item.appendChild(badge);
+      }
+      const img = document.createElement('img');
+      img.className = 'exercise-gif';
+      img.alt = '';
+      const info = document.createElement('div');
+      info.className = 'exercise-info';
+      const title = document.createElement('h3');
+      title.textContent = name;
+      info.appendChild(title);
+      const desc = document.createElement('p');
+      desc.textContent = scenarioDescriptions[name] || 'User-created scenario.';
+      info.appendChild(desc);
+      const hs = document.createElement('p');
+      hs.className = 'high-score';
+      hs.textContent = `High Score: ${high}`;
+      info.appendChild(hs);
+      item.appendChild(img);
+      item.appendChild(info);
+      list.appendChild(item);
+    }
   });
 
   const trainer = document.querySelector('.exercise-item[data-link="shape_trainer.html"]');


### PR DESCRIPTION
## Summary
- Add Triangles drill card to Memorization menu
- Initialize existing cards with scenario data to avoid duplicates and show scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a73a1b68d48325931fd7c4b899a9eb