### PR TITLE
Improve triangle drill visuals and timing

### DIFF
--- a/triangles.js
+++ b/triangles.js
@@ -9,7 +9,7 @@ let guesses = [];
 let guessesGreyed = false;
 let attemptCount = 0;
 
-const SHOW_COLOR_TIME = 2000;
+const SHOW_COLOR_TIME = 500;
 const NEW_TRIANGLE_DELAY = 3000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -43,20 +43,13 @@ function drawGuesses() {
 function drawTriangle(show = true) {
   clearCanvas(ctx);
   if (show) {
-    ctx.strokeStyle = 'black';
-    ctx.lineWidth = 2;
+    ctx.fillStyle = 'black';
     ctx.beginPath();
     ctx.moveTo(vertices[0].x, vertices[0].y);
     ctx.lineTo(vertices[1].x, vertices[1].y);
     ctx.lineTo(vertices[2].x, vertices[2].y);
     ctx.closePath();
-    ctx.stroke();
-    vertices.forEach(v => {
-      ctx.fillStyle = 'black';
-      ctx.beginPath();
-      ctx.arc(v.x, v.y, 5, 0, Math.PI * 2);
-      ctx.fill();
-    });
+    ctx.fill();
   }
   drawGuesses();
 }
@@ -84,22 +77,26 @@ function nearestVertex(pos) {
 function finishCycle() {
   state = 'waiting';
   const success = guesses.every(g => g.grade === 'green');
+  attemptCount++;
   drawTriangle(true);
-  setTimeout(() => {
-    guessesGreyed = true;
-    drawTriangle(true);
-    attemptCount++;
-    if (success) {
-      result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
-      setTimeout(() => {
-        result.textContent = '';
-        attemptCount = 0;
-        startTriangle();
-      }, NEW_TRIANGLE_DELAY);
-    } else {
+  if (success) {
+    result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
+    setTimeout(() => {
+      guessesGreyed = true;
+      drawTriangle(true);
+    }, SHOW_COLOR_TIME);
+    setTimeout(() => {
+      result.textContent = '';
+      attemptCount = 0;
+      startTriangle();
+    }, NEW_TRIANGLE_DELAY);
+  } else {
+    setTimeout(() => {
+      guessesGreyed = true;
+      drawTriangle(true);
       state = 'preview';
-    }
-  }, SHOW_COLOR_TIME);
+    }, SHOW_COLOR_TIME);
+  }
 }
 
 function pointerDown(e) {


### PR DESCRIPTION
## Summary
- Render triangles as solid black polygons
- Grey out guesses faster and report success immediately
- Maintain 3s delay before generating the next triangle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73e422a10832581f53956a7925f76