### PR TITLE
Add quadrilateral memorization drill

### DIFF
--- a/memorization.html
+++ b/memorization.html
@@ -27,6 +27,14 @@
           <p>Memorize triangle vertices.</p>
         </div>
       </div>
+      <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
+        <span class="difficulty-label difficulty-adept">Adept</span>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Quadrilaterals</h3>
+          <p>Memorize quadrilateral vertices.</p>
+        </div>
+      </div>
     </div>
   </div>
   <script src="back.js"></script>

--- a/quadrilaterals.html
+++ b/quadrilaterals.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Quadrilaterals - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Quadrilaterals</h2>
+    <button id="startBtn">Start</button>
+    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <p class="score" id="result"></p>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="quadrilaterals.js"></script>
+</body>
+</html>

--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -1,0 +1,149 @@
+import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { generateShape } from './geometry.js';
+
+let canvas, ctx, startBtn, result;
+let playing = false;
+let state = 'idle';
+let vertices = [];
+let remaining = [];
+let guesses = [];
+let guessesGreyed = false;
+let attemptCount = 0;
+
+const SHOW_COLOR_TIME = 2000;
+const NEW_QUADRILATERAL_DELAY = 3000;
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+function generateQuadrilateral() {
+  vertices = generateShape(4, canvas.width, canvas.height);
+}
+
+function drawGuesses() {
+  guesses.forEach(g => {
+    const color = guessesGreyed ? 'grey' : g.grade === 'yellow' ? 'orange' : g.grade;
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(g.x, g.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawQuadrilateral(show = true) {
+  clearCanvas(ctx);
+  if (show) {
+    ctx.strokeStyle = 'black';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(vertices[0].x, vertices[0].y);
+    for (let i = 1; i < vertices.length; i++) {
+      ctx.lineTo(vertices[i].x, vertices[i].y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+    vertices.forEach(v => {
+      ctx.fillStyle = 'black';
+      ctx.beginPath();
+      ctx.arc(v.x, v.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  }
+  drawGuesses();
+}
+
+function gradeDistance(d) {
+  if (d <= 5) return 'green';
+  if (d <= 10) return 'yellow';
+  return 'red';
+}
+
+function nearestVertex(pos) {
+  let minIdx = remaining[0];
+  let minDist = Infinity;
+  remaining.forEach(idx => {
+    const v = vertices[idx];
+    const d = Math.hypot(pos.x - v.x, pos.y - v.y);
+    if (d < minDist) {
+      minDist = d;
+      minIdx = idx;
+    }
+  });
+  return { idx: minIdx, dist: minDist };
+}
+
+function finishCycle() {
+  state = 'waiting';
+  const success = guesses.every(g => g.grade === 'green');
+  drawQuadrilateral(true);
+  setTimeout(() => {
+    guessesGreyed = true;
+    drawQuadrilateral(true);
+    attemptCount++;
+    if (success) {
+      result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
+      setTimeout(() => {
+        result.textContent = '';
+        attemptCount = 0;
+        startQuadrilateral();
+      }, NEW_QUADRILATERAL_DELAY);
+    } else {
+      state = 'preview';
+    }
+  }, SHOW_COLOR_TIME);
+}
+
+function pointerDown(e) {
+  if (!playing) return;
+  const pos = getCanvasPos(canvas, e);
+  if (state === 'preview') {
+    guesses = [];
+    guessesGreyed = false;
+    remaining = [0, 1, 2, 3];
+    const { idx, dist } = nearestVertex(pos);
+    const grade = gradeDistance(dist);
+    guesses.push({ x: pos.x, y: pos.y, grade });
+    playSound(audioCtx, grade);
+    remaining.splice(remaining.indexOf(idx), 1);
+    state = 'guess';
+    clearCanvas(ctx);
+    drawGuesses();
+  } else if (state === 'guess') {
+    const { idx, dist } = nearestVertex(pos);
+    const grade = gradeDistance(dist);
+    guesses.push({ x: pos.x, y: pos.y, grade });
+    playSound(audioCtx, grade);
+    remaining.splice(remaining.indexOf(idx), 1);
+    clearCanvas(ctx);
+    drawGuesses();
+    if (remaining.length === 0) {
+      finishCycle();
+    }
+  }
+}
+
+function startQuadrilateral() {
+  generateQuadrilateral();
+  guesses = [];
+  guessesGreyed = false;
+  remaining = [0, 1, 2, 3];
+  state = 'preview';
+  drawQuadrilateral(true);
+}
+
+function startGame() {
+  audioCtx.resume();
+  playing = true;
+  startBtn.disabled = true;
+  result.textContent = '';
+  attemptCount = 0;
+  startQuadrilateral();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('gameCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  startBtn = document.getElementById('startBtn');
+  result = document.getElementById('result');
+  canvas.addEventListener('pointerdown', pointerDown);
+  startBtn.addEventListener('click', startGame);
+});

--- a/scenarios.js
+++ b/scenarios.js
@@ -5,7 +5,8 @@ export const scenarioUrls = {
   "Point Drill 0.5 sec Look": 'point_drill_05.html',
   "Point Drill 0.25 sec Look": 'point_drill_025.html',
   "Point Drill 0.1 sec Look": 'point_drill_01.html',
-  "Triangles": 'triangles.html'
+  "Triangles": 'triangles.html',
+  "Quadrilaterals": 'quadrilaterals.html'
 };
 
 export const scenarioDescriptions = {
@@ -15,7 +16,8 @@ export const scenarioDescriptions = {
   "Point Drill 0.5 sec Look": 'Memorize a point after a 0.5 second preview and tap its location.',
   "Point Drill 0.25 sec Look": 'Memorize a point after a 0.25 second preview and tap its location.',
   "Point Drill 0.1 sec Look": 'Memorize a point after a 0.1 second preview and tap its location.',
-  "Triangles": 'Memorize triangle vertices.'
+  "Triangles": 'Memorize triangle vertices.',
+  "Quadrilaterals": 'Memorize quadrilateral vertices.'
 };
 
 export const scenarioDifficulty = {
@@ -25,7 +27,8 @@ export const scenarioDifficulty = {
   "Point Drill 0.5 sec Look": 'Beginner',
   "Point Drill 0.25 sec Look": 'Adept',
   "Point Drill 0.1 sec Look": 'Expert',
-  "Triangles": 'Beginner'
+  "Triangles": 'Beginner',
+  "Quadrilaterals": 'Adept'
 };
 
 const builtInScenarios = Object.fromEntries(


### PR DESCRIPTION
## Summary
- create quadrilaterals memorization drill for four-sided shapes
- list Quadrilaterals exercise on memorization screen and scenarios with Adept difficulty
- refactor quadrilateral drill to use shared generateShape helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73e96f1748325bc1e65ddd6f29258