### PR TITLE
Add category tags for drill cards

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -6,7 +6,10 @@ describe('memorization page', () => {
     document.body.innerHTML = `
       <div id="exerciseList" class="exercise-list">
         <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
-          <span class="difficulty-label difficulty-beginner">Beginner</span>
+          <div class="tag-container">
+            <span class="category-label">Memorization</span>
+            <span class="difficulty-label difficulty-beginner">Beginner</span>
+          </div>
           <img class="exercise-gif" alt="" />
           <div class="exercise-info">
             <h3>Shape Trainer</h3>

--- a/dexterity.html
+++ b/dexterity.html
@@ -12,7 +12,10 @@
     <h2>Dexterity Drills</h2>
     <div id="exerciseList" class="exercise-list">
       <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
-        <span class="difficulty-label difficulty-beginner">Beginner</span>
+        <div class="tag-container">
+          <span class="category-label">dexterity</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Large Points</h3>
@@ -20,7 +23,10 @@
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept" data-score-key="dexterity_point_drill">
-        <span class="difficulty-label difficulty-adept">Adept</span>
+        <div class="tag-container">
+          <span class="category-label">dexterity</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Medium Points</h3>
@@ -28,7 +34,10 @@
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert" data-score-key="dexterity_point_drill_small">
-        <span class="difficulty-label difficulty-expert">Expert</span>
+        <div class="tag-container">
+          <span class="category-label">dexterity</span>
+          <span class="difficulty-label difficulty-expert">Expert</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Small Points</h3>
@@ -36,7 +45,10 @@
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
-        <span class="difficulty-label difficulty-beginner">Beginner</span>
+        <div class="tag-container">
+          <span class="category-label">dexterity</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Thick Lines</h3>
@@ -44,7 +56,10 @@
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
-        <span class="difficulty-label difficulty-adept">Adept</span>
+        <div class="tag-container">
+          <span class="category-label">dexterity</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Thin Lines</h3>

--- a/memorization.html
+++ b/memorization.html
@@ -12,7 +12,10 @@
     <h2>Memorization</h2>
     <div id="exerciseList" class="exercise-list">
       <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
-        <span class="difficulty-label difficulty-beginner">Beginner</span>
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Shape Trainer</h3>
@@ -20,7 +23,10 @@
         </div>
       </div>
       <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
-        <span class="difficulty-label difficulty-beginner">Beginner</span>
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Triangles</h3>
@@ -28,7 +34,10 @@
         </div>
       </div>
       <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
-        <span class="difficulty-label difficulty-adept">Adept</span>
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Quadrilaterals</h3>

--- a/memorization.js
+++ b/memorization.js
@@ -11,12 +11,25 @@ function init() {
       .find(item => item.querySelector('h3')?.textContent === name);
     if (existing) {
       existing.dataset.link = getScenarioUrl(name);
+      let container = existing.querySelector('.tag-container');
+      if (!container) {
+        container = document.createElement('div');
+        container.className = 'tag-container';
+        existing.insertBefore(container, existing.firstChild);
+      }
+      let cat = container.querySelector('.category-label');
+      if (!cat) {
+        cat = document.createElement('span');
+        cat.className = 'category-label';
+        cat.textContent = 'Memorization';
+        container.appendChild(cat);
+      }
       if (diff) {
         existing.dataset.difficulty = diff;
-        let badge = existing.querySelector('.difficulty-label');
+        let badge = container.querySelector('.difficulty-label');
         if (!badge) {
           badge = document.createElement('span');
-          existing.insertBefore(badge, existing.firstChild);
+          container.appendChild(badge);
         }
         badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
         badge.textContent = diff;
@@ -33,13 +46,20 @@ function init() {
       const item = document.createElement('div');
       item.className = 'exercise-item';
       item.dataset.link = getScenarioUrl(name);
+      const container = document.createElement('div');
+      container.className = 'tag-container';
+      const cat = document.createElement('span');
+      cat.className = 'category-label';
+      cat.textContent = 'Memorization';
+      container.appendChild(cat);
       if (diff) {
         item.dataset.difficulty = diff;
         const badge = document.createElement('span');
         badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
         badge.textContent = diff;
-        item.appendChild(badge);
+        container.appendChild(badge);
       }
+      item.appendChild(container);
       const img = document.createElement('img');
       img.className = 'exercise-gif';
       img.alt = '';

--- a/scenarios.js
+++ b/scenarios.js
@@ -62,13 +62,20 @@ function loadScenarioList() {
     const item = document.createElement('div');
     item.className = 'exercise-item';
     const diff = scenarioDifficulty[name];
+    const tags = document.createElement('div');
+    tags.className = 'tag-container';
+    const cat = document.createElement('span');
+    cat.className = 'category-label';
+    cat.textContent = 'Memorization';
+    tags.appendChild(cat);
     if (diff) {
       item.dataset.difficulty = diff;
       const badge = document.createElement('span');
       badge.className = `difficulty-label difficulty-${diff.toLowerCase()}`;
       badge.textContent = diff;
-      item.appendChild(badge);
+      tags.appendChild(badge);
     }
+    item.appendChild(tags);
     const img = document.createElement('img');
     img.className = 'exercise-gif';
     img.alt = '';

--- a/style.css
+++ b/style.css
@@ -322,14 +322,24 @@ h2, h1 { margin: 10px 0; }
   color: #555;
 }
 
-.difficulty-label {
+.tag-container {
   position: absolute;
   top: 5px;
   right: 5px;
+  display: flex;
+  gap: 5px;
+}
+
+.difficulty-label,
+.category-label {
   padding: 4px 8px;
   border-radius: 10px;
   font-size: 12px;
   color: #fff;
+}
+
+.category-label {
+  background-color: #9e9e9e;
 }
 
 .difficulty-beginner {


### PR DESCRIPTION
## Summary
- add gray category labels positioned left of difficulty badges
- tag memorization drills with "Memorization" and dexterity drills with "dexterity"
- ensure dynamic scenarios display the new category tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a89d0ca4fc83258477a7b6e350934f