### PR TITLE
Improve complex shape generation and grading accuracy

### DIFF
--- a/complex_shapes.js
+++ b/complex_shapes.js
@@ -102,7 +102,8 @@ function curveIntersects(points) {
 
 function generateComplexShape() {
   const sides = 2 + Math.floor(Math.random() * 2); // up to 3 sides
-  const sizes = ['small', 'medium', 'big'];
+  // Bias toward larger shapes by weighting 'medium' and 'big' sizes
+  const sizes = ['small', 'medium', 'medium', 'big', 'big'];
   const size = sizes[Math.floor(Math.random() * sizes.length)];
   const verts = generateShape(sides, canvas.width, canvas.height, size);
   segments = [];
@@ -215,7 +216,9 @@ function distanceToPath(p) {
 function evaluateDrawing() {
   if (playerShape.length < 2) return 0;
   drawComplexShape(true);
-  return correctSamples / Math.max(totalSamples, 1);
+  const coverage = Math.min(totalSamples / polyline.length, 1);
+  const pathAccuracy = correctSamples / Math.max(totalSamples, 1);
+  return pathAccuracy * coverage;
 }
 
 function startShape() {


### PR DESCRIPTION
## Summary
- Bias complex shape generator toward larger results
- Ensure drawings cover enough of the contour before grading as correct

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a913fc2d408325b852919611df3fe9