### PR TITLE
Unify drills menu and add search capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shape Trainer is a small browser game where you try to memorize and recreate ran
 ## Running the Game
 
 1. Open `index.html` in any modern web browser. No build step or server is required—just open the file directly.
-2. The menu provides buttons for **Memorization**, **Dexterity**, and **About**. The Memorization menu includes the **Shape Trainer** and a list of scenario challenges.
+2. The menu provides buttons for **Drills**, **Observation**, and **About**. The Drills menu combines memorization and dexterity exercises and includes a search bar.
 
 ## Basic Controls
 

--- a/drills.html
+++ b/drills.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Drills - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="menu-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Drills</h2>
+    <input id="searchInput" type="text" placeholder="Search drills..." />
+    <div id="exerciseList" class="exercise-list">
+      <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Shape Trainer</h3>
+          <p>Train with custom shapes and settings.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Triangles</h3>
+          <p>Memorize triangle vertices.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Quadrilaterals</h3>
+          <p>Memorize quadrilateral vertices.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-expert">Expert</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Complex Shapes</h3>
+          <p>Memorize mixed curved and straight shapes.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
+        <div class="tag-container">
+          <span class="category-label">Dexterity</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Large Points</h3>
+          <p>Point drill with larger targets for easier accuracy.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept" data-score-key="dexterity_point_drill">
+        <div class="tag-container">
+          <span class="category-label">Dexterity</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Medium Points</h3>
+          <p>Improve pointer accuracy with rapid taps.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert" data-score-key="dexterity_point_drill_small">
+        <div class="tag-container">
+          <span class="category-label">Dexterity</span>
+          <span class="difficulty-label difficulty-expert">Expert</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Small Points</h3>
+          <p>Point drill with smaller targets for higher precision.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
+        <div class="tag-container">
+          <span class="category-label">Dexterity</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Thick Lines</h3>
+          <p>Trace thicker lines for an easier challenge.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
+        <div class="tag-container">
+          <span class="category-label">Dexterity</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Thin Lines</h3>
+          <p>Practice tracing thin lines of different lengths and directions.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="memorization.js"></script>
+  <script type="module" src="drills.js"></script>
+</body>
+</html>

--- a/drills.js
+++ b/drills.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Add high scores for dexterity drills
+  document.querySelectorAll('.exercise-item[data-score-key]').forEach(item => {
+    const info = item.querySelector('.exercise-info');
+    const key = item.dataset.scoreKey;
+    if (info && key) {
+      const val = localStorage.getItem(key) || 0;
+      const p = document.createElement('p');
+      p.className = 'high-score';
+      p.textContent = `High Score: ${val}`;
+      info.appendChild(p);
+    }
+  });
+
+  // Search filter
+  const search = document.getElementById('searchInput');
+  if (search) {
+    search.addEventListener('input', () => {
+      const term = search.value.toLowerCase();
+      document.querySelectorAll('.exercise-item').forEach(item => {
+        const title = item.querySelector('h3')?.textContent.toLowerCase() || '';
+        item.style.display = title.includes(term) ? '' : 'none';
+      });
+    });
+  }
+
+  // Navigate on click
+  document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
+    item.addEventListener('click', () => {
+      window.location.href = item.dataset.link;
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -11,8 +11,7 @@
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Shape Trainer</h1>
     <p>by Sawyer Wall</p>
-    <button id="memorizationBtn">Memorization</button>
-    <button id="dexterityBtn">Dexterity</button>
+    <button id="drillsBtn">Drills</button>
     <button id="observationBtn">Observation</button>
     <button id="aboutBtn">About</button>
   </div>

--- a/index.js
+++ b/index.js
@@ -5,11 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const freeEl = document.getElementById('freehandBest');
   if (p2pEl) p2pEl.textContent = p2pBest ? `${parseFloat(p2pBest).toFixed(1)} px` : 'N/A';
   if (freeEl) freeEl.textContent = freehandBest ? `${parseFloat(freehandBest).toFixed(1)} px` : 'N/A';
-  document.getElementById('memorizationBtn')?.addEventListener('click', () => {
-    window.location.href = 'memorization.html';
-  });
-  document.getElementById('dexterityBtn')?.addEventListener('click', () => {
-    window.location.href = 'dexterity.html';
+  document.getElementById('drillsBtn')?.addEventListener('click', () => {
+    window.location.href = 'drills.html';
   });
   document.getElementById('observationBtn')?.addEventListener('click', () => {
     window.location.href = 'observation.html';


### PR DESCRIPTION
## Summary
- Replace separate Memorization and Dexterity menu buttons with a single Drills option
- Introduce new Drills page combining memorization and dexterity exercises with search
- Update README for new navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a93acc12ac83259562105de28a9ab5