### PR TITLE
Fix drills navigation handlers

### DIFF
--- a/__tests__/drills.test.js
+++ b/__tests__/drills.test.js
@@ -1,0 +1,18 @@
+/** @jest-environment jsdom */
+
+import { jest } from '@jest/globals';
+
+describe('drills page', () => {
+  test('exercise items get click handlers even if DOM already loaded', async () => {
+    document.body.innerHTML = `
+      <div class="exercise-item" data-link="test.html">
+        <div class="exercise-info"><h3>Test</h3></div>
+      </div>
+    `;
+    const item = document.querySelector('.exercise-item');
+    const spy = jest.spyOn(item, 'addEventListener');
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    await import('../drills.js');
+    expect(spy).toHaveBeenCalledWith('click', expect.any(Function));
+  });
+});

--- a/drills.js
+++ b/drills.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
   // Add high scores for dexterity drills
   document.querySelectorAll('.exercise-item[data-score-key]').forEach(item => {
     const info = item.querySelector('.exercise-info');
@@ -27,7 +27,13 @@ document.addEventListener('DOMContentLoaded', () => {
   // Navigate on click
   document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
     item.addEventListener('click', () => {
-      window.location.href = item.dataset.link;
+      window.location.assign(item.dataset.link);
     });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}


### PR DESCRIPTION
## Summary
- ensure drill cards initialize even if DOM already loaded
- add regression test for drill card click handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a93c4deb6c8325b527210916fab60c