### PR TITLE
Remove observation option from main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <h1>Shape Trainer</h1>
     <p>by Sawyer Wall</p>
     <button id="drillsBtn">Drills</button>
-    <button id="observationBtn">Observation</button>
     <button id="aboutBtn">About</button>
   </div>
   <script src="index.js"></script>

--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('drillsBtn')?.addEventListener('click', () => {
     window.location.href = 'drills.html';
   });
-  document.getElementById('observationBtn')?.addEventListener('click', () => {
-    window.location.href = 'observation.html';
-  });
   document.getElementById('aboutBtn')?.addEventListener('click', () => {
     window.location.href = 'about.html';
   });


### PR DESCRIPTION
## Summary
- remove Observation button from landing page menu
- drop observation menu navigation handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a93ce5f9148325a3b79d91c8a9f6a5