### PR TITLE
Fix drill cards layout and script logic

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -10,10 +10,6 @@
   <div class="menu-screen">
     <button id="backBtn">← Back</button>
     <h2>Drills</h2>
-    <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
-        <div class="tag-container">
-          <span class="category-label">dexterity</span>
     <input id="searchInput" type="text" placeholder="Search drills..." />
     <div id="exerciseList" class="exercise-list">
       <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
@@ -73,7 +69,6 @@
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept" data-score-key="dexterity_point_drill">
         <div class="tag-container">
-          <span class="category-label">dexterity</span>
           <span class="category-label">Dexterity</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
@@ -85,7 +80,6 @@
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert" data-score-key="dexterity_point_drill_small">
         <div class="tag-container">
-          <span class="category-label">dexterity</span>
           <span class="category-label">Dexterity</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
@@ -97,7 +91,6 @@
       </div>
       <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
         <div class="tag-container">
-          <span class="category-label">dexterity</span>
           <span class="category-label">Dexterity</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
@@ -109,7 +102,6 @@
       </div>
       <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
         <div class="tag-container">
-          <span class="category-label">dexterity</span>
           <span class="category-label">Dexterity</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
@@ -121,7 +113,7 @@
       </div>
       <div class="exercise-item" data-link="dexterity_contours.html" data-difficulty="Expert" data-score-key="dexterity_contours">
         <div class="tag-container">
-          <span class="category-label">dexterity</span>
+          <span class="category-label">Dexterity</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -133,10 +125,6 @@
     </div>
   </div>
   <script src="back.js"></script>
-    </div>
-  </div>
-  <script src="back.js"></script>
-  <script type="module" src="memorization.js"></script>
   <script type="module" src="drills.js"></script>
 </body>
 </html>

--- a/drills.js
+++ b/drills.js
@@ -1,8 +1,6 @@
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
 function init() {
   // Add high scores for dexterity drills
-  document.querySelectorAll('.exercise-item[data-score-key]').forEach(item => {
+  document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
     const info = item.querySelector('.exercise-info');
     const key = item.dataset.scoreKey;
     if (info && key) {
@@ -16,8 +14,6 @@ function init() {
       window.location.href = item.dataset.link;
     });
   });
-});
-  });
 
   // Search filter
   const search = document.getElementById('searchInput');
@@ -30,13 +26,6 @@ function init() {
       });
     });
   }
-
-  // Navigate on click
-  document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
-    item.addEventListener('click', () => {
-      window.location.assign(item.dataset.link);
-    });
-  });
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Clean up drills page markup to list all exercises once and add search bar
- Simplify drills script to attach clicks, show high scores, and filter by search

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9bee5e0048325befb8b33254f5d91