### PR TITLE
Restore angle and point memorization drills to menu

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -56,11 +56,66 @@
           <p>Memorize mixed curved and straight shapes.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
+      <div class="exercise-item" data-link="angles.html" data-difficulty="Expert">
         <div class="tag-container">
-          <span class="category-label">Dexterity</span>
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-expert">Expert</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Angles (5° increments)</h3>
+          <p>Guess randomly oriented angles in 5° steps.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="angles.html?step=10" data-difficulty="Beginner">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Angles (10° increments)</h3>
+          <p>Guess randomly oriented angles in 10° steps.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="point_drill_05.html" data-difficulty="Beginner">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-beginner">Beginner</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Point Drill 0.5 sec Look</h3>
+          <p>Memorize a point after a 0.5 second preview and tap its location.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="point_drill_025.html" data-difficulty="Adept">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Point Drill 0.25 sec Look</h3>
+          <p>Memorize a point after a 0.25 second preview and tap its location.</p>
+        </div>
+      </div>
+      <div class="exercise-item" data-link="point_drill_01.html" data-difficulty="Expert">
+        <div class="tag-container">
+          <span class="category-label">Memorization</span>
+          <span class="difficulty-label difficulty-expert">Expert</span>
+        </div>
+        <img class="exercise-gif" alt="" />
+        <div class="exercise-info">
+          <h3>Point Drill 0.1 sec Look</h3>
+          <p>Memorize a point after a 0.1 second preview and tap its location.</p>
+        </div>
+      </div>
+        <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
+          <div class="tag-container">
+            <span class="category-label">Dexterity</span>
+            <span class="difficulty-label difficulty-beginner">Beginner</span>
+          </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
           <h3>Large Points</h3>


### PR DESCRIPTION
## Summary
- Reintroduce angle drills with 5° and 10° increments to the drills menu
- Add point memorization drills with 0.5s, 0.25s, and 0.1s preview times

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9dadd858c832597c64f6dc66c5109