### PR TITLE
Colorize memorization and dexterity tags

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -7,7 +7,7 @@ describe('memorization page', () => {
       <div id="exerciseList" class="exercise-list">
         <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
           <div class="tag-container">
-            <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
             <span class="difficulty-label difficulty-beginner">Beginner</span>
           </div>
           <img class="exercise-gif" alt="" />

--- a/drills.html
+++ b/drills.html
@@ -14,7 +14,7 @@
     <div id="exerciseList" class="exercise-list">
       <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -25,7 +25,7 @@
       </div>
       <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -36,7 +36,7 @@
       </div>
       <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -47,7 +47,7 @@
       </div>
       <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -58,7 +58,7 @@
       </div>
       <div class="exercise-item" data-link="angles.html" data-difficulty="Expert">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -69,7 +69,7 @@
       </div>
       <div class="exercise-item" data-link="angles.html?step=10" data-difficulty="Beginner">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -80,7 +80,7 @@
       </div>
       <div class="exercise-item" data-link="point_drill_05.html" data-difficulty="Beginner">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -91,7 +91,7 @@
       </div>
       <div class="exercise-item" data-link="point_drill_025.html" data-difficulty="Adept">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -102,7 +102,7 @@
       </div>
       <div class="exercise-item" data-link="point_drill_01.html" data-difficulty="Expert">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+            <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -113,7 +113,7 @@
       </div>
         <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
           <div class="tag-container">
-            <span class="category-label">Dexterity</span>
+            <span class="category-label category-dexterity">Dexterity</span>
             <span class="difficulty-label difficulty-beginner">Beginner</span>
           </div>
         <img class="exercise-gif" alt="" />
@@ -124,7 +124,7 @@
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept" data-score-key="dexterity_point_drill">
         <div class="tag-container">
-          <span class="category-label">Dexterity</span>
+            <span class="category-label category-dexterity">Dexterity</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -135,7 +135,7 @@
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert" data-score-key="dexterity_point_drill_small">
         <div class="tag-container">
-          <span class="category-label">Dexterity</span>
+            <span class="category-label category-dexterity">Dexterity</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -146,7 +146,7 @@
       </div>
       <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
         <div class="tag-container">
-          <span class="category-label">Dexterity</span>
+            <span class="category-label category-dexterity">Dexterity</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -157,7 +157,7 @@
       </div>
       <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
         <div class="tag-container">
-          <span class="category-label">Dexterity</span>
+            <span class="category-label category-dexterity">Dexterity</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -168,7 +168,7 @@
       </div>
       <div class="exercise-item" data-link="dexterity_contours.html" data-difficulty="Expert" data-score-key="dexterity_contours">
         <div class="tag-container">
-          <span class="category-label">Dexterity</span>
+            <span class="category-label category-dexterity">Dexterity</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />

--- a/memorization.html
+++ b/memorization.html
@@ -13,7 +13,7 @@
     <div id="exerciseList" class="exercise-list">
       <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+          <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -24,7 +24,7 @@
       </div>
       <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+          <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -35,7 +35,7 @@
       </div>
       <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+          <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -46,7 +46,7 @@
       </div>
       <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">
         <div class="tag-container">
-          <span class="category-label">Memorization</span>
+          <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />

--- a/memorization.js
+++ b/memorization.js
@@ -17,13 +17,15 @@ function init() {
         container.className = 'tag-container';
         existing.insertBefore(container, existing.firstChild);
       }
-      let cat = container.querySelector('.category-label');
-      if (!cat) {
-        cat = document.createElement('span');
-        cat.className = 'category-label';
-        cat.textContent = 'Memorization';
-        container.appendChild(cat);
-      }
+        let cat = container.querySelector('.category-label');
+        if (!cat) {
+          cat = document.createElement('span');
+          cat.className = 'category-label category-memorization';
+          cat.textContent = 'Memorization';
+          container.appendChild(cat);
+        } else {
+          cat.classList.add('category-memorization');
+        }
       if (diff) {
         existing.dataset.difficulty = diff;
         let badge = container.querySelector('.difficulty-label');
@@ -48,9 +50,9 @@ function init() {
       item.dataset.link = getScenarioUrl(name);
       const container = document.createElement('div');
       container.className = 'tag-container';
-      const cat = document.createElement('span');
-      cat.className = 'category-label';
-      cat.textContent = 'Memorization';
+        const cat = document.createElement('span');
+        cat.className = 'category-label category-memorization';
+        cat.textContent = 'Memorization';
       container.appendChild(cat);
       if (diff) {
         item.dataset.difficulty = diff;

--- a/scenarios.js
+++ b/scenarios.js
@@ -65,7 +65,7 @@ function loadScenarioList() {
     const tags = document.createElement('div');
     tags.className = 'tag-container';
     const cat = document.createElement('span');
-    cat.className = 'category-label';
+    cat.className = 'category-label category-memorization';
     cat.textContent = 'Memorization';
     tags.appendChild(cat);
     if (diff) {

--- a/style.css
+++ b/style.css
@@ -342,6 +342,14 @@ h2, h1 { margin: 10px 0; }
   background-color: #9e9e9e;
 }
 
+.category-memorization {
+  background-color: #82B3B3;
+}
+
+.category-dexterity {
+  background-color: #B382B3;
+}
+
 .difficulty-beginner {
   background-color: #4CAF50;
 }


### PR DESCRIPTION
## Summary
- Add low-chroma teal and purple backgrounds for memorization and dexterity tags
- Apply new category classes across drills, memorization, and scenario lists
- Update related tests for new class names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e8454444832580c1012a30d1754c