### PR TITLE
Show final strike point and style strike markers

### DIFF
--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -118,16 +118,15 @@ function pointerDown(e) {
     if (grade === 'red') {
       strikes++;
       updateStrikes();
-      if (strikes >= 3) {
-        endGame();
-        return;
-      }
     }
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
     clearCanvas(ctx);
     drawGuesses();
+    if (strikes >= 3) {
+      endGame();
+    }
   } else if (state === 'guess') {
     const { idx, dist } = nearestVertex(pos);
     const grade = gradeDistance(dist);
@@ -135,16 +134,14 @@ function pointerDown(e) {
     if (grade === 'red') {
       strikes++;
       updateStrikes();
-      if (strikes >= 3) {
-        endGame();
-        return;
-      }
     }
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
     drawGuesses();
-    if (remaining.length === 0) {
+    if (strikes >= 3) {
+      endGame();
+    } else if (remaining.length === 0) {
       finishCycle();
     }
   }

--- a/style.css
+++ b/style.css
@@ -368,16 +368,19 @@ h2, h1 { margin: 10px 0; }
   margin-top: 10px;
 }
 .strikes input[type="checkbox"] {
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
   appearance: none;
-  border: 1px solid #000;
+  border: 1px solid #333;
+  background-color: transparent;
   position: relative;
+  box-sizing: border-box;
 }
 .strikes input[type="checkbox"]:checked::after {
-  content: '✖';
+  content: '\2717';
   position: absolute;
-  top: -2px;
-  left: 3px;
+  top: -3px;
+  left: 2px;
   color: red;
+  font-size: 18px;
 }

--- a/triangles.js
+++ b/triangles.js
@@ -129,16 +129,15 @@ function pointerDown(e) {
     if (grade === 'red') {
       strikes++;
       updateStrikes();
-      if (strikes >= 3) {
-        endGame();
-        return;
-      }
     }
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
     clearCanvas(ctx);
     drawGuesses();
+    if (strikes >= 3) {
+      endGame();
+    }
   } else if (state === 'guess') {
     const { idx, dist } = nearestVertex(pos);
     const grade = gradeDistance(dist);
@@ -146,16 +145,14 @@ function pointerDown(e) {
     if (grade === 'red') {
       strikes++;
       updateStrikes();
-      if (strikes >= 3) {
-        endGame();
-        return;
-      }
     }
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
     drawGuesses();
-    if (remaining.length === 0) {
+    if (strikes >= 3) {
+      endGame();
+    } else if (remaining.length === 0) {
       finishCycle();
     }
   }


### PR DESCRIPTION
## Summary
- Ensure final strike's point and audio play before ending triangle and quadrilateral drills
- Restyle strike boxes with transparent backgrounds and red X icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9eb03d4a483259f382a026a1e7df8