### PR TITLE
Align contour grading parameters with thin lines

### DIFF
--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -15,8 +15,9 @@ let lastPos = null;
 let offLineSegments = 0;
 let totalSegments = 0;
 
-const tolerance = 6;
-const maxOffSegmentRatio = 0.15;
+// Match grading parameters with dexterity_thin_lines.js
+const tolerance = 4;
+const maxOffSegmentRatio = 0.1;
 const LINE_WIDTH = 2;
 const SAMPLE_POINTS = 50;
 


### PR DESCRIPTION
## Summary
- Match contour drawing mode's tolerance and off-line segment ratio with thin lines mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9edf2832483259e923b8ee60dae64