### PR TITLE
Implement attempt-based three strikes rule for complex shapes, triangles, and quadrilaterals

### DIFF
--- a/complex_shapes.html
+++ b/complex_shapes.html
@@ -12,6 +12,11 @@
     <h2>Complex Shapes</h2>
     <button id="startBtn">Start</button>
     <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <div id="strikes" class="strikes">
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+    </div>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -11,6 +11,7 @@ let guessesGreyed = false;
 let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
+let attemptHasRed = false;
 
 const SHOW_COLOR_TIME = 500;
 const NEW_QUADRILATERAL_DELAY = 3000;
@@ -97,6 +98,14 @@ function finishCycle() {
       startQuadrilateral();
     }, NEW_QUADRILATERAL_DELAY);
   } else {
+    if (attemptHasRed) {
+      strikes++;
+      updateStrikes();
+      if (strikes >= 3) {
+        endGame();
+        return;
+      }
+    }
     setTimeout(() => {
       guessesGreyed = true;
       drawQuadrilateral(true);
@@ -112,36 +121,26 @@ function pointerDown(e) {
     guesses = [];
     guessesGreyed = false;
     remaining = [0, 1, 2, 3];
+    attemptHasRed = false;
     const { idx, dist } = nearestVertex(pos);
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
-    if (grade === 'red') {
-      strikes++;
-      updateStrikes();
-    }
+    if (grade === 'red') attemptHasRed = true;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
     clearCanvas(ctx);
     drawGuesses();
-    if (strikes >= 3) {
-      endGame();
-    }
   } else if (state === 'guess') {
     const { idx, dist } = nearestVertex(pos);
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
-    if (grade === 'red') {
-      strikes++;
-      updateStrikes();
-    }
+    if (grade === 'red') attemptHasRed = true;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
     drawGuesses();
-    if (strikes >= 3) {
-      endGame();
-    } else if (remaining.length === 0) {
+    if (remaining.length === 0) {
       finishCycle();
     }
   }

--- a/triangles.js
+++ b/triangles.js
@@ -10,6 +10,7 @@ let guessesGreyed = false;
 let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
+let attemptHasRed = false;
 
 const SHOW_COLOR_TIME = 500;
 const NEW_TRIANGLE_DELAY = 3000;
@@ -108,6 +109,14 @@ function finishCycle() {
       startTriangle();
     }, NEW_TRIANGLE_DELAY);
   } else {
+    if (attemptHasRed) {
+      strikes++;
+      updateStrikes();
+      if (strikes >= 3) {
+        endGame();
+        return;
+      }
+    }
     setTimeout(() => {
       guessesGreyed = true;
       drawTriangle(true);
@@ -123,36 +132,26 @@ function pointerDown(e) {
     guesses = [];
     guessesGreyed = false;
     remaining = [0, 1, 2];
+    attemptHasRed = false;
     const { idx, dist } = nearestVertex(pos);
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
-    if (grade === 'red') {
-      strikes++;
-      updateStrikes();
-    }
+    if (grade === 'red') attemptHasRed = true;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
     clearCanvas(ctx);
     drawGuesses();
-    if (strikes >= 3) {
-      endGame();
-    }
   } else if (state === 'guess') {
     const { idx, dist } = nearestVertex(pos);
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
-    if (grade === 'red') {
-      strikes++;
-      updateStrikes();
-    }
+    if (grade === 'red') attemptHasRed = true;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
     drawGuesses();
-    if (strikes >= 3) {
-      endGame();
-    } else if (remaining.length === 0) {
+    if (remaining.length === 0) {
       finishCycle();
     }
   }


### PR DESCRIPTION
## Summary
- Track strikes per attempt instead of per red dot in triangle and quadrilateral drills
- End games after three failed attempts that include red guesses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9eef959dc8325873640922321b75f