### PR TITLE
Remove Shape Trainer from drill listings

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -4,19 +4,7 @@ import { scenarioUrls, scenarioDescriptions } from '../scenarios.js';
 describe('memorization page', () => {
   test('lists built-in scenarios when DOM already loaded', async () => {
     document.body.innerHTML = `
-      <div id="exerciseList" class="exercise-list">
-        <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
-          <div class="tag-container">
-            <span class="category-label category-memorization">Memorization</span>
-            <span class="difficulty-label difficulty-beginner">Beginner</span>
-          </div>
-          <img class="exercise-gif" alt="" />
-          <div class="exercise-info">
-            <h3>Shape Trainer</h3>
-            <p>Train with custom shapes and settings.</p>
-          </div>
-        </div>
-      </div>
+      <div id="exerciseList" class="exercise-list"></div>
     `;
 
     Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
@@ -27,12 +15,11 @@ describe('memorization page', () => {
         title: item.querySelector('h3')?.textContent,
         desc: item.querySelector('p')?.textContent
       }));
-    expect(items).toEqual([
-      { title: 'Shape Trainer', desc: 'Train with custom shapes and settings.' },
-      ...Object.keys(scenarioUrls).map(name => ({
+    expect(items).toEqual(
+      Object.keys(scenarioUrls).map(name => ({
         title: name,
         desc: scenarioDescriptions[name]
       }))
-    ]);
+    );
   });
 });

--- a/drills.html
+++ b/drills.html
@@ -12,17 +12,6 @@
     <h2>Drills</h2>
     <input id="searchInput" type="text" placeholder="Search drills..." />
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
-        <div class="tag-container">
-            <span class="category-label category-memorization">Memorization</span>
-          <span class="difficulty-label difficulty-beginner">Beginner</span>
-        </div>
-        <img class="exercise-gif" alt="" />
-        <div class="exercise-info">
-          <h3>Shape Trainer</h3>
-          <p>Train with custom shapes and settings.</p>
-        </div>
-      </div>
       <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>

--- a/memorization.html
+++ b/memorization.html
@@ -11,17 +11,6 @@
     <button id="backBtn">← Back</button>
     <h2>Memorization</h2>
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="shape_trainer.html" data-difficulty="Beginner">
-        <div class="tag-container">
-          <span class="category-label category-memorization">Memorization</span>
-          <span class="difficulty-label difficulty-beginner">Beginner</span>
-        </div>
-        <img class="exercise-gif" alt="" />
-        <div class="exercise-info">
-          <h3>Shape Trainer</h3>
-          <p>Train with custom shapes and settings.</p>
-        </div>
-      </div>
       <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
         <div class="tag-container">
           <span class="category-label category-memorization">Memorization</span>


### PR DESCRIPTION
## Summary
- remove Shape Trainer from drill selection pages
- adjust memorization test to match updated menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f0982d408325824e1b940fa841a3