### PR TITLE
Prevent overly skinny shapes in memorization drills

### DIFF
--- a/__tests__/geometry.test.js
+++ b/__tests__/geometry.test.js
@@ -15,6 +15,16 @@ describe('generateShape', () => {
     });
   });
 
+  test('avoids excessively skinny shapes', () => {
+    const points = generateShape(4, width, height, 'medium');
+    const xs = points.map(p => p.x);
+    const ys = points.map(p => p.y);
+    const boxWidth = Math.max(...xs) - Math.min(...xs);
+    const boxHeight = Math.max(...ys) - Math.min(...ys);
+    expect(boxWidth).toBeGreaterThanOrEqual(60);
+    expect(boxHeight).toBeGreaterThanOrEqual(60);
+  });
+
   test('handles single point generation', () => {
     const points = generateShape(1, width, height);
     expect(points).toHaveLength(1);

--- a/geometry.js
+++ b/geometry.js
@@ -12,22 +12,31 @@ export function generateShape(sides, width, height, size = 'medium') {
     big: 180
   };
   const radius = sizeMap[size] || 120;
+  const minDim = 60;
 
   const cx = width / 2;
   const cy = height / 2;
-  const angleOffset = Math.random() * Math.PI * 2;
-
-  const points = [];
   const angleStep = (2 * Math.PI) / sides;
+  let points = [];
+  let boxWidth = 0;
+  let boxHeight = 0;
 
-  for (let i = 0; i < sides; i++) {
-    const angle = angleStep * i + angleOffset;
-    const r = radius * (0.4 + Math.random() * 0.8);
-    points.push({
-      x: cx + r * Math.cos(angle),
-      y: cy + r * Math.sin(angle)
-    });
-  }
+  do {
+    const angleOffset = Math.random() * Math.PI * 2;
+    points = [];
+    for (let i = 0; i < sides; i++) {
+      const angle = angleStep * i + angleOffset;
+      const r = radius * (0.4 + Math.random() * 0.8);
+      points.push({
+        x: cx + r * Math.cos(angle),
+        y: cy + r * Math.sin(angle)
+      });
+    }
+    const xs = points.map(p => p.x);
+    const ys = points.map(p => p.y);
+    boxWidth = Math.max(...xs) - Math.min(...xs);
+    boxHeight = Math.max(...ys) - Math.min(...ys);
+  } while (boxWidth < minDim || boxHeight < minDim);
 
   return points;
 }

--- a/triangles.js
+++ b/triangles.js
@@ -18,18 +18,23 @@ const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateTriangle() {
   const margin = 40;
-  let pts, area;
+  const minDim = 60;
+  let pts, area, width, height;
   do {
     pts = Array.from({ length: 3 }, () => ({
       x: Math.random() * (canvas.width - 2 * margin) + margin,
       y: Math.random() * (canvas.height - 2 * margin) + margin
     }));
+    const xs = pts.map(p => p.x);
+    const ys = pts.map(p => p.y);
+    width = Math.max(...xs) - Math.min(...xs);
+    height = Math.max(...ys) - Math.min(...ys);
     area = Math.abs(
       pts[0].x * (pts[1].y - pts[2].y) +
       pts[1].x * (pts[2].y - pts[0].y) +
       pts[2].x * (pts[0].y - pts[1].y)
     ) / 2;
-  } while (area < 100); // ensure not too small
+  } while (area < 100 || width < minDim || height < minDim);
   vertices = pts;
 }
 


### PR DESCRIPTION
## Summary
- ensure generated shapes have a minimum width and height to avoid skinny shapes
- enforce minimum dimensions when generating triangles
- add regression test verifying shape generator avoids thin shapes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f4ff4134832587e985e8ccab2e0f