### PR TITLE
Add subject tags for drills

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -15,6 +15,7 @@
       <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Shapes</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -26,6 +27,7 @@
       <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Shapes</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -37,6 +39,7 @@
       <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Shapes</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -48,6 +51,7 @@
       <div class="exercise-item" data-link="angles.html" data-difficulty="Expert">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Angles</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -59,6 +63,7 @@
       <div class="exercise-item" data-link="angles.html?step=10" data-difficulty="Beginner">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Angles</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -70,6 +75,7 @@
       <div class="exercise-item" data-link="point_drill_05.html" data-difficulty="Beginner">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -81,6 +87,7 @@
       <div class="exercise-item" data-link="point_drill_025.html" data-difficulty="Adept">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -92,6 +99,7 @@
       <div class="exercise-item" data-link="point_drill_01.html" data-difficulty="Expert">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
@@ -102,8 +110,9 @@
       </div>
         <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
           <div class="tag-container">
-            <span class="category-label category-dexterity">Dexterity</span>
-            <span class="difficulty-label difficulty-beginner">Beginner</span>
+              <span class="category-label category-dexterity">Dexterity</span>
+              <span class="subject-label">Points</span>
+              <span class="difficulty-label difficulty-beginner">Beginner</span>
           </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -113,8 +122,9 @@
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill.html" data-difficulty="Adept" data-score-key="dexterity_point_drill">
         <div class="tag-container">
-            <span class="category-label category-dexterity">Dexterity</span>
-          <span class="difficulty-label difficulty-adept">Adept</span>
+              <span class="category-label category-dexterity">Dexterity</span>
+            <span class="subject-label">Points</span>
+            <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -124,8 +134,9 @@
       </div>
       <div class="exercise-item" data-link="dexterity_point_drill_small.html" data-difficulty="Expert" data-score-key="dexterity_point_drill_small">
         <div class="tag-container">
-            <span class="category-label category-dexterity">Dexterity</span>
-          <span class="difficulty-label difficulty-expert">Expert</span>
+              <span class="category-label category-dexterity">Dexterity</span>
+            <span class="subject-label">Points</span>
+            <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -135,8 +146,9 @@
       </div>
       <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
         <div class="tag-container">
-            <span class="category-label category-dexterity">Dexterity</span>
-          <span class="difficulty-label difficulty-beginner">Beginner</span>
+              <span class="category-label category-dexterity">Dexterity</span>
+            <span class="subject-label">Lines</span>
+            <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -146,8 +158,9 @@
       </div>
       <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
         <div class="tag-container">
-            <span class="category-label category-dexterity">Dexterity</span>
-          <span class="difficulty-label difficulty-adept">Adept</span>
+              <span class="category-label category-dexterity">Dexterity</span>
+            <span class="subject-label">Lines</span>
+            <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
@@ -157,8 +170,9 @@
       </div>
       <div class="exercise-item" data-link="dexterity_contours.html" data-difficulty="Expert" data-score-key="dexterity_contours">
         <div class="tag-container">
-            <span class="category-label category-dexterity">Dexterity</span>
-          <span class="difficulty-label difficulty-expert">Expert</span>
+              <span class="category-label category-dexterity">Dexterity</span>
+            <span class="subject-label">Lines</span>
+            <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">

--- a/memorization.html
+++ b/memorization.html
@@ -36,6 +36,7 @@
       <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">
         <div class="tag-container">
           <span class="category-label category-memorization">Memorization</span>
+          <span class="subject-label">Shapes</span>
           <span class="difficulty-label difficulty-expert">Expert</span>
         </div>
         <img class="exercise-gif" alt="" />

--- a/memorization.js
+++ b/memorization.js
@@ -1,4 +1,4 @@
-import { scenarioUrls, getScenarioUrl, scenarioDescriptions, scenarioDifficulty } from './scenarios.js';
+import { scenarioUrls, getScenarioUrl, scenarioDescriptions, scenarioDifficulty, scenarioSubject } from './scenarios.js';
 
 function init() {
   const list = document.getElementById('exerciseList');
@@ -6,6 +6,7 @@ function init() {
   const scenarios = [...Object.keys(scenarioUrls), ...Object.keys(saved)];
   scenarios.forEach(name => {
     const diff = scenarioDifficulty[name];
+    const subject = scenarioSubject[name];
     const high = localStorage.getItem(`scenarioScore_${name}`) || 0;
     const existing = Array.from(list.querySelectorAll('.exercise-item'))
       .find(item => item.querySelector('h3')?.textContent === name);
@@ -26,6 +27,20 @@ function init() {
         } else {
           cat.classList.add('category-memorization');
         }
+      if (subject) {
+        let subj = container.querySelector('.subject-label');
+        if (!subj) {
+          subj = document.createElement('span');
+          subj.className = 'subject-label';
+        }
+        subj.textContent = subject;
+        const diffBadge = container.querySelector('.difficulty-label');
+        if (diffBadge) {
+          container.insertBefore(subj, diffBadge);
+        } else {
+          container.appendChild(subj);
+        }
+      }
       if (diff) {
         existing.dataset.difficulty = diff;
         let badge = container.querySelector('.difficulty-label');
@@ -54,6 +69,12 @@ function init() {
         cat.className = 'category-label category-memorization';
         cat.textContent = 'Memorization';
       container.appendChild(cat);
+      if (subject) {
+        const subj = document.createElement('span');
+        subj.className = 'subject-label';
+        subj.textContent = subject;
+        container.appendChild(subj);
+      }
       if (diff) {
         item.dataset.difficulty = diff;
         const badge = document.createElement('span');

--- a/scenarios.js
+++ b/scenarios.js
@@ -31,6 +31,18 @@ export const scenarioDifficulty = {
   "Quadrilaterals": 'Adept'
 };
 
+export const scenarioSubject = {
+  "Angles (5\u00B0 increments)": 'Angles',
+  "Angles (10\u00B0 increments)": 'Angles',
+  "Inch Drill": 'Lines',
+  "Point Drill 0.5 sec Look": 'Points',
+  "Point Drill 0.25 sec Look": 'Points',
+  "Point Drill 0.1 sec Look": 'Points',
+  "Triangles": 'Shapes',
+  "Quadrilaterals": 'Shapes',
+  "Complex Shapes": 'Shapes'
+};
+
 const builtInScenarios = Object.fromEntries(
   Object.keys(scenarioUrls).map(name => [name, { special: true }])
 );
@@ -62,12 +74,19 @@ function loadScenarioList() {
     const item = document.createElement('div');
     item.className = 'exercise-item';
     const diff = scenarioDifficulty[name];
+    const subject = scenarioSubject[name];
     const tags = document.createElement('div');
     tags.className = 'tag-container';
     const cat = document.createElement('span');
     cat.className = 'category-label category-memorization';
     cat.textContent = 'Memorization';
     tags.appendChild(cat);
+    if (subject) {
+      const subj = document.createElement('span');
+      subj.className = 'subject-label';
+      subj.textContent = subject;
+      tags.appendChild(subj);
+    }
     if (diff) {
       item.dataset.difficulty = diff;
       const badge = document.createElement('span');

--- a/style.css
+++ b/style.css
@@ -331,7 +331,8 @@ h2, h1 { margin: 10px 0; }
 }
 
 .difficulty-label,
-.category-label {
+.category-label,
+.subject-label {
   padding: 4px 8px;
   border-radius: 10px;
   font-size: 12px;
@@ -340,6 +341,10 @@ h2, h1 { margin: 10px 0; }
 
 .category-label {
   background-color: #9e9e9e;
+}
+
+.subject-label {
+  background-color: #bdbdbd;
 }
 
 .category-memorization {


### PR DESCRIPTION
## Summary
- add subject tag styling and options for Points, Lines, Angles, and Shapes
- show subject tags on drill cards
- attach subject metadata to built-in scenarios and dynamic lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f57173d483258184d8bd6ef53cf1