### PR TITLE
refactor: centralize scenario data

### DIFF
--- a/__tests__/memorization.test.js
+++ b/__tests__/memorization.test.js
@@ -1,5 +1,5 @@
 /** @jest-environment jsdom */
-import { scenarioUrls, scenarioDescriptions } from '../scenarios.js';
+import { scenarioData } from '../scenarios.js';
 
 describe('memorization page', () => {
   test('lists built-in scenarios when DOM already loaded', async () => {
@@ -16,9 +16,9 @@ describe('memorization page', () => {
         desc: item.querySelector('p')?.textContent
       }));
     expect(items).toEqual(
-      Object.keys(scenarioUrls).map(name => ({
+      Object.entries(scenarioData).map(([name, data]) => ({
         title: name,
-        desc: scenarioDescriptions[name]
+        desc: data.description
       }))
     );
   });

--- a/memorization.js
+++ b/memorization.js
@@ -1,12 +1,13 @@
-import { scenarioUrls, getScenarioUrl, scenarioDescriptions, scenarioDifficulty, scenarioSubject } from './scenarios.js';
+import { scenarioData, getScenarioUrl } from './scenarios.js';
 
 function init() {
   const list = document.getElementById('exerciseList');
   const saved = JSON.parse(localStorage.getItem('scenarios') || '{}');
-  const scenarios = [...Object.keys(scenarioUrls), ...Object.keys(saved)];
-  scenarios.forEach(name => {
-    const diff = scenarioDifficulty[name];
-    const subject = scenarioSubject[name];
+  const scenarioNames = [...Object.keys(scenarioData), ...Object.keys(saved)];
+  scenarioNames.forEach(name => {
+    const data = scenarioData[name] || {};
+    const diff = data.difficulty;
+    const subject = data.subject;
     const high = localStorage.getItem(`scenarioScore_${name}`) || 0;
     const existing = Array.from(list.querySelectorAll('.exercise-item'))
       .find(item => item.querySelector('h3')?.textContent === name);
@@ -92,7 +93,7 @@ function init() {
       title.textContent = name;
       info.appendChild(title);
       const desc = document.createElement('p');
-      desc.textContent = scenarioDescriptions[name] || 'User-created scenario.';
+      desc.textContent = data.description || 'User-created scenario.';
       info.appendChild(desc);
       const hs = document.createElement('p');
       hs.className = 'high-score';

--- a/scenarios.js
+++ b/scenarios.js
@@ -1,50 +1,60 @@
-export const scenarioUrls = {
-  "Angles (5\u00B0 increments)": 'angles.html',
-  "Angles (10\u00B0 increments)": 'angles.html?step=10',
-  "Inch Drill": 'inch_warmup.html',
-  "Point Drill 0.5 sec Look": 'point_drill_05.html',
-  "Point Drill 0.25 sec Look": 'point_drill_025.html',
-  "Point Drill 0.1 sec Look": 'point_drill_01.html',
-  "Triangles": 'triangles.html',
-  "Quadrilaterals": 'quadrilaterals.html'
+export const scenarioData = {
+  "Angles (5\u00B0 increments)": {
+    url: 'angles.html',
+    description: 'Guess randomly oriented angles in 5\u00B0 steps.',
+    difficulty: 'Expert',
+    subject: 'Angles'
+  },
+  "Angles (10\u00B0 increments)": {
+    url: 'angles.html?step=10',
+    description: 'Guess randomly oriented angles in 10\u00B0 steps.',
+    difficulty: 'Beginner',
+    subject: 'Angles'
+  },
+  "Inch Drill": {
+    url: 'inch_warmup.html',
+    description: 'Draw a 1-inch line from a given starting arrow.',
+    difficulty: 'Beginner',
+    subject: 'Lines'
+  },
+  "Point Drill 0.5 sec Look": {
+    url: 'point_drill_05.html',
+    description: 'Memorize a point after a 0.5 second preview and tap its location.',
+    difficulty: 'Beginner',
+    subject: 'Points'
+  },
+  "Point Drill 0.25 sec Look": {
+    url: 'point_drill_025.html',
+    description: 'Memorize a point after a 0.25 second preview and tap its location.',
+    difficulty: 'Adept',
+    subject: 'Points'
+  },
+  "Point Drill 0.1 sec Look": {
+    url: 'point_drill_01.html',
+    description: 'Memorize a point after a 0.1 second preview and tap its location.',
+    difficulty: 'Expert',
+    subject: 'Points'
+  },
+  "Triangles": {
+    url: 'triangles.html',
+    description: 'Memorize triangle vertices.',
+    difficulty: 'Beginner',
+    subject: 'Shapes'
+  },
+  "Quadrilaterals": {
+    url: 'quadrilaterals.html',
+    description: 'Memorize quadrilateral vertices.',
+    difficulty: 'Adept',
+    subject: 'Shapes'
+  }
 };
 
-export const scenarioDescriptions = {
-  "Angles (5\u00B0 increments)": 'Guess randomly oriented angles in 5\u00B0 steps.',
-  "Angles (10\u00B0 increments)": 'Guess randomly oriented angles in 10\u00B0 steps.',
-  "Inch Drill": 'Draw a 1-inch line from a given starting arrow.',
-  "Point Drill 0.5 sec Look": 'Memorize a point after a 0.5 second preview and tap its location.',
-  "Point Drill 0.25 sec Look": 'Memorize a point after a 0.25 second preview and tap its location.',
-  "Point Drill 0.1 sec Look": 'Memorize a point after a 0.1 second preview and tap its location.',
-  "Triangles": 'Memorize triangle vertices.',
-  "Quadrilaterals": 'Memorize quadrilateral vertices.'
-};
-
-export const scenarioDifficulty = {
-  "Angles (5\u00B0 increments)": 'Expert',
-  "Angles (10\u00B0 increments)": 'Beginner',
-  "Inch Drill": 'Beginner',
-  "Point Drill 0.5 sec Look": 'Beginner',
-  "Point Drill 0.25 sec Look": 'Adept',
-  "Point Drill 0.1 sec Look": 'Expert',
-  "Triangles": 'Beginner',
-  "Quadrilaterals": 'Adept'
-};
-
-export const scenarioSubject = {
-  "Angles (5\u00B0 increments)": 'Angles',
-  "Angles (10\u00B0 increments)": 'Angles',
-  "Inch Drill": 'Lines',
-  "Point Drill 0.5 sec Look": 'Points',
-  "Point Drill 0.25 sec Look": 'Points',
-  "Point Drill 0.1 sec Look": 'Points',
-  "Triangles": 'Shapes',
-  "Quadrilaterals": 'Shapes',
-  "Complex Shapes": 'Shapes'
-};
+export const scenarioUrls = Object.fromEntries(
+  Object.entries(scenarioData).map(([name, data]) => [name, data.url])
+);
 
 const builtInScenarios = Object.fromEntries(
-  Object.keys(scenarioUrls).map(name => [name, { special: true }])
+  Object.keys(scenarioData).map(name => [name, { special: true }])
 );
 
 function getSavedScenarios() {
@@ -73,8 +83,9 @@ function loadScenarioList() {
   getScenarioNames().forEach(name => {
     const item = document.createElement('div');
     item.className = 'exercise-item';
-    const diff = scenarioDifficulty[name];
-    const subject = scenarioSubject[name];
+    const data = scenarioData[name] || {};
+    const diff = data.difficulty;
+    const subject = data.subject;
     const tags = document.createElement('div');
     tags.className = 'tag-container';
     const cat = document.createElement('span');


### PR DESCRIPTION
## Summary
- centralize scenario metadata in a single `scenarioData` object
- update memorization page to consume unified scenario metadata
- adjust memorization tests for new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab627f0c8083258b717710fec8d61d