### PR TITLE
Fix main menu navigation and remove unused options

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,7 @@
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Shape Trainer</h1>
     <p>by Sawyer Wall</p>
-    <button id="memorizationBtn">Memorization</button>
     <button id="drillsBtn">Drills</button>
-    <button id="observationBtn">Observation</button>
     <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>
   </div>

--- a/index.js
+++ b/index.js
@@ -1,18 +1,20 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const p2pBest = localStorage.getItem('p2pBest');
-  const freehandBest = localStorage.getItem('freehandBest');
+  let p2pBest = null;
+  let freehandBest = null;
+  try {
+    p2pBest = localStorage.getItem('p2pBest');
+    freehandBest = localStorage.getItem('freehandBest');
+  } catch {
+    // localStorage might be unavailable; ignore errors
+  }
+
   const p2pEl = document.getElementById('p2pBest');
   const freeEl = document.getElementById('freehandBest');
   if (p2pEl) p2pEl.textContent = p2pBest ? `${parseFloat(p2pBest).toFixed(1)} px` : 'N/A';
   if (freeEl) freeEl.textContent = freehandBest ? `${parseFloat(freehandBest).toFixed(1)} px` : 'N/A';
-document.getElementById('memorizationBtn')?.addEventListener('click', () => {
-    window.location.href = 'memorization.html';
-  });
+
   document.getElementById('drillsBtn')?.addEventListener('click', () => {
     window.location.href = 'drills.html';
-  });
-  document.getElementById('observationBtn')?.addEventListener('click', () => {
-    window.location.href = 'observation.html';
   });
   document.getElementById('scenariosBtn')?.addEventListener('click', () => {
     window.location.href = 'scenarios.html';


### PR DESCRIPTION
## Summary
- Remove memorization and observation entries from the main menu
- Harden main menu script and wire up remaining navigation buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab68436f30832594f0e1c2bdda4305