### PR TITLE
Enable playing custom scenarios

### DIFF
--- a/drills_data.js
+++ b/drills_data.js
@@ -1,0 +1,17 @@
+export const drills = [
+  { name: 'Triangles', url: 'triangles.html', description: 'Memorize triangle vertices.', category: 'Memorization', subject: 'Shapes', difficulty: 'Beginner' },
+  { name: 'Quadrilaterals', url: 'quadrilaterals.html', description: 'Memorize quadrilateral vertices.', category: 'Memorization', subject: 'Shapes', difficulty: 'Adept' },
+  { name: 'Complex Shapes', url: 'complex_shapes.html', description: 'Memorize mixed curved and straight shapes.', category: 'Memorization', subject: 'Shapes', difficulty: 'Expert' },
+  { name: 'Angles (5° increments)', url: 'angles.html', description: 'Guess randomly oriented angles in 5° steps.', category: 'Memorization', subject: 'Angles', difficulty: 'Expert' },
+  { name: 'Angles (10° increments)', url: 'angles.html?step=10', description: 'Guess randomly oriented angles in 10° steps.', category: 'Memorization', subject: 'Angles', difficulty: 'Beginner' },
+  { name: 'Point Drill 0.5 sec Look', url: 'point_drill_05.html', description: 'Memorize a point after a 0.5 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Beginner' },
+  { name: 'Point Drill 0.25 sec Look', url: 'point_drill_025.html', description: 'Memorize a point after a 0.25 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
+  { name: 'Point Drill 0.1 sec Look', url: 'point_drill_01.html', description: 'Memorize a point after a 0.1 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Expert' },
+  { name: 'Large Points', url: 'dexterity_point_drill_large.html', description: 'Point drill with larger targets for easier accuracy.', category: 'Dexterity', subject: 'Points', difficulty: 'Beginner' },
+  { name: 'Medium Points', url: 'dexterity_point_drill.html', description: 'Improve pointer accuracy with rapid taps.', category: 'Dexterity', subject: 'Points', difficulty: 'Adept' },
+  { name: 'Small Points', url: 'dexterity_point_drill_small.html', description: 'Point drill with smaller targets for higher precision.', category: 'Dexterity', subject: 'Points', difficulty: 'Expert' },
+  { name: 'Thick Lines', url: 'dexterity_thick_lines.html', description: 'Trace thicker lines for an easier challenge.', category: 'Dexterity', subject: 'Lines', difficulty: 'Beginner' },
+  { name: 'Thin Lines', url: 'dexterity_thin_lines.html', description: 'Practice tracing thin lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
+  { name: 'Thick Contours', url: 'dexterity_thick_contours.html', description: 'Trace thick C and S curves for smoother control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
+  { name: 'Contours', url: 'dexterity_contours.html', description: 'Trace C and S shaped curves for advanced control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Expert' }
+];

--- a/scenario_player.html
+++ b/scenario_player.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Play Scenario - Memory Shape Drawing Game</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button id="backBtn">← Back</button>
+    <h2 id="scenarioTitle"></h2>
+    <iframe id="drillFrame" width="500" height="500" style="border:none;"></iframe>
+    <button id="nextBtn">Next Drill</button>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="scenario_player.js"></script>
+</body>
+</html>

--- a/scenario_player.js
+++ b/scenario_player.js
@@ -1,0 +1,50 @@
+import { drills } from './drills_data.js';
+
+function loadScenarios() {
+  try {
+    return JSON.parse(localStorage.getItem('userScenarios') || '{}');
+  } catch {
+    return {};
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  const name = params.get('name');
+  const titleEl = document.getElementById('scenarioTitle');
+  const frame = document.getElementById('drillFrame');
+  const nextBtn = document.getElementById('nextBtn');
+
+  if (titleEl) titleEl.textContent = name || 'Scenario';
+
+  const scenarios = loadScenarios();
+  const steps = scenarios[name] || [];
+  const urlMap = Object.fromEntries(drills.map(d => [d.name, d.url]));
+  const sequence = [];
+  steps.forEach(step => {
+    const url = urlMap[step.name];
+    if (!url) return;
+    for (let i = 0; i < (step.repeats || 1); i++) {
+      sequence.push(url);
+    }
+  });
+
+  let index = 0;
+
+  function loadCurrent() {
+    if (index < sequence.length) {
+      frame.src = sequence[index];
+    } else {
+      frame.style.display = 'none';
+      nextBtn.disabled = true;
+      if (titleEl) titleEl.textContent = `${name} - Complete!`;
+    }
+  }
+
+  nextBtn.addEventListener('click', () => {
+    index++;
+    loadCurrent();
+  });
+
+  loadCurrent();
+});

--- a/scenarios_page.js
+++ b/scenarios_page.js
@@ -1,20 +1,4 @@
-const drills = [
-  { name: 'Triangles', url: 'triangles.html', description: 'Memorize triangle vertices.', category: 'Memorization', subject: 'Shapes', difficulty: 'Beginner' },
-  { name: 'Quadrilaterals', url: 'quadrilaterals.html', description: 'Memorize quadrilateral vertices.', category: 'Memorization', subject: 'Shapes', difficulty: 'Adept' },
-  { name: 'Complex Shapes', url: 'complex_shapes.html', description: 'Memorize mixed curved and straight shapes.', category: 'Memorization', subject: 'Shapes', difficulty: 'Expert' },
-  { name: 'Angles (5° increments)', url: 'angles.html', description: 'Guess randomly oriented angles in 5° steps.', category: 'Memorization', subject: 'Angles', difficulty: 'Expert' },
-  { name: 'Angles (10° increments)', url: 'angles.html?step=10', description: 'Guess randomly oriented angles in 10° steps.', category: 'Memorization', subject: 'Angles', difficulty: 'Beginner' },
-  { name: 'Point Drill 0.5 sec Look', url: 'point_drill_05.html', description: 'Memorize a point after a 0.5 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Beginner' },
-  { name: 'Point Drill 0.25 sec Look', url: 'point_drill_025.html', description: 'Memorize a point after a 0.25 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
-  { name: 'Point Drill 0.1 sec Look', url: 'point_drill_01.html', description: 'Memorize a point after a 0.1 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Expert' },
-  { name: 'Large Points', url: 'dexterity_point_drill_large.html', description: 'Point drill with larger targets for easier accuracy.', category: 'Dexterity', subject: 'Points', difficulty: 'Beginner' },
-  { name: 'Medium Points', url: 'dexterity_point_drill.html', description: 'Improve pointer accuracy with rapid taps.', category: 'Dexterity', subject: 'Points', difficulty: 'Adept' },
-  { name: 'Small Points', url: 'dexterity_point_drill_small.html', description: 'Point drill with smaller targets for higher precision.', category: 'Dexterity', subject: 'Points', difficulty: 'Expert' },
-  { name: 'Thick Lines', url: 'dexterity_thick_lines.html', description: 'Trace thicker lines for an easier challenge.', category: 'Dexterity', subject: 'Lines', difficulty: 'Beginner' },
-  { name: 'Thin Lines', url: 'dexterity_thin_lines.html', description: 'Practice tracing thin lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
-  { name: 'Thick Contours', url: 'dexterity_thick_contours.html', description: 'Trace thick C and S curves for smoother control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
-  { name: 'Contours', url: 'dexterity_contours.html', description: 'Trace C and S shaped curves for advanced control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Expert' }
-];
+import { drills } from './drills_data.js';
 
 const diffMap = { Beginner: 1, Adept: 2, Expert: 3 };
 const diffReverse = { 1: 'Beginner', 2: 'Adept', 3: 'Expert' };
@@ -85,6 +69,9 @@ function renderScenarioList() {
     info.appendChild(h3);
     info.appendChild(p);
     item.appendChild(info);
+    item.addEventListener('click', () => {
+      window.location.href = `scenario_player.html?name=${encodeURIComponent(title)}`;
+    });
     container.appendChild(item);
   });
 }


### PR DESCRIPTION
## Summary
- Extract shared drill metadata to `drills_data.js`
- Make saved scenarios clickable and route to a new player page
- Add scenario player page that loads each drill in sequence with a Next button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6b539a888325a8497268b28163d5