### PR TITLE
fix: resize scenario iframe to avoid cropping

### DIFF
--- a/scenario_player.js
+++ b/scenario_player.js
@@ -15,6 +15,25 @@ document.addEventListener('DOMContentLoaded', () => {
   const frame = document.getElementById('drillFrame');
   const nextBtn = document.getElementById('nextBtn');
 
+  let observer;
+
+  const resizeFrame = () => {
+    try {
+      const doc = frame.contentDocument || frame.contentWindow.document;
+      if (!doc) return;
+      frame.style.height = doc.documentElement.scrollHeight + 'px';
+      if (observer) observer.disconnect();
+      observer = new ResizeObserver(() => {
+        frame.style.height = doc.documentElement.scrollHeight + 'px';
+      });
+      observer.observe(doc.documentElement);
+    } catch {
+      // Ignore cross-origin access errors
+    }
+  };
+
+  frame.addEventListener('load', resizeFrame);
+
   if (titleEl) titleEl.textContent = name || 'Scenario';
 
   const scenarios = loadScenarios();


### PR DESCRIPTION
## Summary
- resize scenario player iframe to the height of its content
- observe drill page size changes to keep the full canvas visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6e6db1f88325b82f8d0fc1144440