### PR TITLE
Auto advance scenario drills with consistent canvas size

### DIFF
--- a/scenario_player.html
+++ b/scenario_player.html
@@ -10,7 +10,6 @@
   <div class="practice-screen">
     <button id="backBtn">← Back</button>
     <iframe id="drillFrame" width="500" height="500" style="border:none; overflow:hidden;" scrolling="no"></iframe>
-    <button id="nextBtn">Next Drill</button>
   </div>
   <script src="back.js"></script>
   <script type="module" src="scenario_player.js"></script>


### PR DESCRIPTION
## Summary
- Remove manual next button and second drill back button in scenario player
- Automatically proceed to the next drill after displaying the score briefly
- Keep the drill canvas at a consistent size by removing scaling logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab769686288325bbb268778156b67f