### PR TITLE
Fix scenario player canvas shrinking after auto-advance

### DIFF
--- a/scenario_player.js
+++ b/scenario_player.js
@@ -22,8 +22,12 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!doc) return;
 
       const updateSize = () => {
-        frame.style.height = doc.documentElement.scrollHeight + 'px';
-        frame.style.width = doc.documentElement.scrollWidth + 'px';
+        const docEl = doc.documentElement;
+        const body = doc.body || {};
+        const height = Math.max(500, docEl.scrollHeight, body.scrollHeight || 0);
+        const width = Math.max(500, docEl.scrollWidth, body.scrollWidth || 0);
+        frame.style.height = height + 'px';
+        frame.style.width = width + 'px';
       };
 
       updateSize();


### PR DESCRIPTION
## Summary
- Ensure the scenario player's iframe never shrinks below drill dimensions when auto-advancing
- Compute size using document and body scroll sizes with a 500px minimum

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7a1da3588325a75bfd015765d316