### PR TITLE
Fix hidden targets in point memorization drills

### DIFF
--- a/__tests__/point_drill_overlay.test.js
+++ b/__tests__/point_drill_overlay.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+
+import { jest } from '@jest/globals';
+
+const modulePath = '../point_drill_05.js';
+
+describe('point drill overlay canvas', () => {
+  test('overlay is transparent', async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <button id="startBtn"></button>
+      <canvas id="gameCanvas" width="500" height="500"></canvas>
+      <p id="result"></p>
+    `;
+    class StubAudioContext {}
+    window.AudioContext = StubAudioContext;
+    window.webkitAudioContext = StubAudioContext;
+    HTMLCanvasElement.prototype.getContext = () => ({
+      canvas: { width: 0, height: 0 }
+    });
+    Object.defineProperty(document, 'readyState', { value: 'loading', configurable: true });
+    await import(`${modulePath}?test=${Date.now()}`);
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const canvases = document.querySelectorAll('canvas');
+    expect(canvases).toHaveLength(2);
+    const feedbackCanvas = canvases[1];
+    expect(feedbackCanvas.style.background).toBe('transparent');
+  });
+});

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -115,6 +115,8 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCanvas.style.left = '0';
   feedbackCanvas.style.top = '0';
   feedbackCanvas.style.pointerEvents = 'none';
+  feedbackCanvas.style.background = 'transparent';
+  feedbackCanvas.style.border = 'none';
   wrapper.appendChild(feedbackCanvas);
 
   ctx = canvas.getContext('2d');

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -115,6 +115,8 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCanvas.style.left = '0';
   feedbackCanvas.style.top = '0';
   feedbackCanvas.style.pointerEvents = 'none';
+  feedbackCanvas.style.background = 'transparent';
+  feedbackCanvas.style.border = 'none';
   wrapper.appendChild(feedbackCanvas);
 
   ctx = canvas.getContext('2d');

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -116,6 +116,9 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCanvas.style.left = '0';
   feedbackCanvas.style.top = '0';
   feedbackCanvas.style.pointerEvents = 'none';
+  // ensure the overlay doesn't obscure the underlying canvas
+  feedbackCanvas.style.background = 'transparent';
+  feedbackCanvas.style.border = 'none';
   wrapper.appendChild(feedbackCanvas);
 
   ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- Prevent feedback overlay from hiding the memorization target in point drills
- Add regression test ensuring overlay canvas stays transparent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9c7bee0c83258c3491b62f20ad47