### PR TITLE
Add interactive tutorial for canvas basics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shape Trainer is a small browser game where you try to memorize and recreate ran
 ## Running the Game
 
 1. Open `index.html` in any modern web browser. No build step or server is required—just open the file directly.
-2. The menu provides buttons for **Drills**, **Observation**, and **About**. The Drills menu combines memorization and dexterity exercises and includes a search bar.
+2. The menu provides buttons for **Tutorial**, **Drills**, **Scenarios**, and **About**. The Drills menu combines memorization and dexterity exercises and includes a search bar.
 
 ## Basic Controls
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Shape Trainer</h1>
     <p>by Sawyer Wall</p>
+    <button id="tutorialBtn">Tutorial</button>
     <button id="drillsBtn">Drills</button>
     <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (p2pEl) p2pEl.textContent = p2pBest ? `${parseFloat(p2pBest).toFixed(1)} px` : 'N/A';
   if (freeEl) freeEl.textContent = freehandBest ? `${parseFloat(freehandBest).toFixed(1)} px` : 'N/A';
 
+  document.getElementById('tutorialBtn')?.addEventListener('click', () => {
+    window.location.href = 'tutorial.html';
+  });
   document.getElementById('drillsBtn')?.addEventListener('click', () => {
     window.location.href = 'drills.html';
   });

--- a/tutorial.html
+++ b/tutorial.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tutorial - Shape Trainer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="practice-screen">
+    <button id="backBtn">← Back</button>
+    <h2>Canvas Tutorial</h2>
+    <p id="instructions">Click "Point-to-Point" to begin.</p>
+    <canvas id="tutorialCanvas" width="500" height="500"></canvas>
+    <div class="button-row">
+      <button id="p2pBtn">Point-to-Point</button>
+      <button id="freehandBtn">Freehand</button>
+    </div>
+    <div id="info">
+      <h3>Drills and Scenarios</h3>
+      <p>Drills isolate individual skills like aiming and drawing smooth lines. Scenarios combine multiple drills into a single challenge so you can apply those skills together.</p>
+    </div>
+  </div>
+  <script src="back.js"></script>
+  <script type="module" src="tutorial.js"></script>
+</body>
+</html>

--- a/tutorial.js
+++ b/tutorial.js
@@ -1,0 +1,94 @@
+import { getCanvasPos, clearCanvas } from './src/utils.js';
+
+let canvas, ctx, instructions;
+let mode = 'idle';
+let points = [];
+let p2pStep = 0;
+let drawing = false;
+let lastPos = null;
+
+function randomPoint() {
+  const margin = 20;
+  return {
+    x: Math.random() * (canvas.width - 2 * margin) + margin,
+    y: Math.random() * (canvas.height - 2 * margin) + margin
+  };
+}
+
+function drawPoints() {
+  clearCanvas(ctx);
+  ctx.fillStyle = 'black';
+  points.forEach(p => {
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function startP2P() {
+  mode = 'p2p';
+  p2pStep = 0;
+  points = [randomPoint(), randomPoint()];
+  drawPoints();
+  instructions.textContent = 'Click the first point, then the second.';
+}
+
+function startFreehand() {
+  mode = 'freehand';
+  drawing = false;
+  clearCanvas(ctx);
+  instructions.textContent = 'Hold and drag on the canvas to draw.';
+}
+
+function handlePointerDown(e) {
+  const pos = getCanvasPos(canvas, e);
+  if (mode === 'p2p') {
+    const target = points[p2pStep];
+    const d = Math.hypot(pos.x - target.x, pos.y - target.y);
+    if (d < 10) {
+      if (p2pStep === 0) {
+        p2pStep = 1;
+      } else {
+        ctx.beginPath();
+        ctx.moveTo(points[0].x, points[0].y);
+        ctx.lineTo(points[1].x, points[1].y);
+        ctx.stroke();
+        instructions.textContent = 'Great! Now try freehand drawing.';
+        mode = 'idle';
+      }
+    }
+  } else if (mode === 'freehand') {
+    drawing = true;
+    lastPos = pos;
+  }
+}
+
+function handlePointerMove(e) {
+  if (mode === 'freehand' && drawing) {
+    const pos = getCanvasPos(canvas, e);
+    ctx.beginPath();
+    ctx.moveTo(lastPos.x, lastPos.y);
+    ctx.lineTo(pos.x, pos.y);
+    ctx.stroke();
+    lastPos = pos;
+  }
+}
+
+function handlePointerUp() {
+  if (mode === 'freehand') {
+    drawing = false;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  canvas = document.getElementById('tutorialCanvas');
+  if (!canvas) return;
+  ctx = canvas.getContext('2d');
+  instructions = document.getElementById('instructions');
+  document.getElementById('p2pBtn')?.addEventListener('click', startP2P);
+  document.getElementById('freehandBtn')?.addEventListener('click', startFreehand);
+  canvas.addEventListener('pointerdown', handlePointerDown);
+  canvas.addEventListener('pointermove', handlePointerMove);
+  canvas.addEventListener('pointerup', handlePointerUp);
+  canvas.addEventListener('pointerleave', handlePointerUp);
+});


### PR DESCRIPTION
## Summary
- add tutorial page teaching point-to-point and freehand canvas interaction
- wire tutorial into main menu and navigation
- document new tutorial entry point in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca314f9088325af13c04f7c7193b5