### PR TITLE
Add menu navigation and improve tutorial visuals

### DIFF
--- a/style.css
+++ b/style.css
@@ -399,18 +399,27 @@ h2, h1 { margin: 10px 0; }
 }
 
 .tutorial-body #message {
-  margin-top: 20px;
+  margin-top: 40px;
   text-align: center;
   padding: 0 10px;
+  font-size: 24px;
+  font-weight: bold;
 }
 
 .tutorial-body #tutorialCanvas {
-  flex-grow: 1;
+  flex: none;
   border: none;
   border-radius: 0;
   background: white;
+  width: min(90vmin, 500px);
+  height: min(90vmin, 500px);
 }
 
 .tutorial-body #nextBtn {
   margin: 20px;
+}
+
+.tutorial-body #backBtn {
+  align-self: flex-start;
+  margin: 10px;
 }

--- a/tutorial.html
+++ b/tutorial.html
@@ -7,9 +7,11 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="tutorial-body">
+  <button id="backBtn">← Main Menu</button>
   <div id="message">Tap the point.</div>
   <canvas id="tutorialCanvas" width="500" height="500"></canvas>
   <button id="nextBtn" style="display:none;">Next</button>
+  <script src="back.js"></script>
   <script type="module" src="tutorial.js"></script>
 </body>
 </html>

--- a/tutorial.js
+++ b/tutorial.js
@@ -3,7 +3,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 let canvas, ctx, message, nextBtn;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const center = { x: 0, y: 0 };
-const DOT_RADIUS = 5;
+const DOT_RADIUS = 10;
 let stage = 0; // 0: waiting for tap, 1: showing grade text, 2: final dots
 let finalDots = [];
 


### PR DESCRIPTION
## Summary
- Add a top "Main Menu" button to tutorial page
- Improve tutorial text styling and layout
- Prevent stretched dots and increase their size

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfc83b8c88325be1077f02126e16f