### PR TITLE
Fix tutorial point accuracy calculation

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getCanvasPos } from '../src/utils.js';
+
+describe('getCanvasPos', () => {
+  test('uses offset coordinates when provided', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 200;
+    Object.defineProperty(canvas, 'clientWidth', { value: 100 });
+    Object.defineProperty(canvas, 'clientHeight', { value: 100 });
+
+    const e = { offsetX: 50, offsetY: 60 };
+    const pos = getCanvasPos(canvas, e);
+    expect(pos).toEqual({ x: 100, y: 120 });
+  });
+
+  test('falls back to client coordinates when offset is missing', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 200;
+    canvas.height = 200;
+    canvas.getBoundingClientRect = () => ({ left: 10, top: 20, width: 100, height: 100 });
+
+    const e = { clientX: 60, clientY: 70 };
+    const pos = getCanvasPos(canvas, e);
+    expect(pos).toEqual({ x: 100, y: 100 });
+  });
+});

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,18 @@
 export function getCanvasPos(canvas, e) {
+  // Use the event's offset coordinates when available. These are already
+  // relative to the canvas' content box, which avoids issues with borders
+  // or page scrolling that can cause inaccurate position calculations on
+  // some devices.
+  if (typeof e.offsetX === 'number' && typeof e.offsetY === 'number') {
+    const scaleX = canvas.width / canvas.clientWidth;
+    const scaleY = canvas.height / canvas.clientHeight;
+    return {
+      x: e.offsetX * scaleX,
+      y: e.offsetY * scaleY
+    };
+  }
+
+  // Fallback: derive the position from the client coordinates.
   const rect = canvas.getBoundingClientRect();
   const scaleX = canvas.width / rect.width;
   const scaleY = canvas.height / rect.height;


### PR DESCRIPTION
## Summary
- improve canvas position calculation by prioritizing event offset coordinates
- add tests for canvas position utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfead5c788325bc2d1c5e6a9c608e