### PR TITLE
Improve tutorial pacing and instructions

### DIFF
--- a/style.css
+++ b/style.css
@@ -415,6 +415,12 @@ h2, h1 { margin: 10px 0; }
   height: min(90vmin, 500px);
 }
 
+.tutorial-body #tapInstruction {
+  margin-top: 10px;
+  text-align: center;
+  font-size: 20px;
+}
+
 .tutorial-body #nextBtn {
   margin: 20px;
 }

--- a/tutorial.html
+++ b/tutorial.html
@@ -10,6 +10,7 @@
   <button id="backBtn">← Main Menu</button>
   <div id="message">Tap the point.</div>
   <canvas id="tutorialCanvas" width="500" height="500"></canvas>
+  <div id="tapInstruction" style="display:none;">Tap the dots to hear their corresponding sound.</div>
   <button id="nextBtn" style="display:none;">Next</button>
   <script src="back.js"></script>
   <script type="module" src="tutorial.js"></script>

--- a/tutorial.js
+++ b/tutorial.js
@@ -1,6 +1,6 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 
-let canvas, ctx, message, nextBtn;
+let canvas, ctx, message, tapInstruction, nextBtn;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const center = { x: 0, y: 0 };
 const DOT_RADIUS = 10;
@@ -34,12 +34,13 @@ function handleInitialTap(e) {
   stage = 1;
   setTimeout(() => {
     message.textContent = grade === 'green' ? 'Accurate' : grade === 'yellow' ? 'Semi-accurate' : 'Inaccurate';
-    setTimeout(showFinalStage, 1000);
+    setTimeout(showFinalStage, 2000);
   }, 500);
 }
 
 function showFinalStage() {
-  message.textContent = 'Many of the drills are based on your ability to accurately see and tap points such as this one. They are colored based on accuracy, and accompanied by sound feed back. Tap the dots to hear their corresponding sound.';
+  message.textContent = 'Many of the drills are based on your ability to accurately see and tap points such as this one. They are colored based on accuracy, and accompanied by sound feed back.';
+  tapInstruction.style.display = 'block';
   drawFinalDots();
   nextBtn.style.display = 'block';
   stage = 2;
@@ -87,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   message = document.getElementById('message');
+  tapInstruction = document.getElementById('tapInstruction');
   nextBtn = document.getElementById('nextBtn');
   center.x = canvas.width / 2;
   center.y = canvas.height / 2;


### PR DESCRIPTION
## Summary
- Lengthen delay before tutorial advances after the initial tap
- Show tap-to-hear instructions alongside final dots instead of within explanation
- Style instruction text to sit with the dots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad010d368c8325878591af7ff84f2a