### PR TITLE
Fix touch coordinate detection for tutorial dots

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -4,25 +4,25 @@
 import { getCanvasPos } from '../src/utils.js';
 
 describe('getCanvasPos', () => {
-  test('uses offset coordinates when provided', () => {
+  test('uses offset coordinates for mouse input', () => {
     const canvas = document.createElement('canvas');
     canvas.width = 200;
     canvas.height = 200;
     Object.defineProperty(canvas, 'clientWidth', { value: 100 });
     Object.defineProperty(canvas, 'clientHeight', { value: 100 });
 
-    const e = { offsetX: 50, offsetY: 60 };
+    const e = { offsetX: 50, offsetY: 60, pointerType: 'mouse' };
     const pos = getCanvasPos(canvas, e);
     expect(pos).toEqual({ x: 100, y: 120 });
   });
 
-  test('falls back to client coordinates when offset is missing', () => {
+  test('falls back to client coordinates for touch input', () => {
     const canvas = document.createElement('canvas');
     canvas.width = 200;
     canvas.height = 200;
     canvas.getBoundingClientRect = () => ({ left: 10, top: 20, width: 100, height: 100 });
 
-    const e = { clientX: 60, clientY: 70 };
+    const e = { clientX: 60, clientY: 70, offsetX: 0, offsetY: 0, pointerType: 'touch' };
     const pos = getCanvasPos(canvas, e);
     expect(pos).toEqual({ x: 100, y: 100 });
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,13 @@
 export function getCanvasPos(canvas, e) {
-  // Use the event's offset coordinates when available. These are already
-  // relative to the canvas' content box, which avoids issues with borders
-  // or page scrolling that can cause inaccurate position calculations on
-  // some devices.
-  if (typeof e.offsetX === 'number' && typeof e.offsetY === 'number') {
+  // On some devices (notably iOS Safari), pointer events report unreliable
+  // `offsetX/Y` values for touch input, which causes taps to be mislocated.
+  // Use `offsetX/Y` only for mouse pointers and fall back to calculating the
+  // position from `clientX/Y` for touch or pen input.
+  if (
+    typeof e.offsetX === 'number' &&
+    typeof e.offsetY === 'number' &&
+    (!('pointerType' in e) || e.pointerType === 'mouse')
+  ) {
     const scaleX = canvas.width / canvas.clientWidth;
     const scaleY = canvas.height / canvas.clientHeight;
     return {


### PR DESCRIPTION
## Summary
- Ensure getCanvasPos ignores unreliable offsetX/Y from touch pointers
- Update utils tests for new pointer handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad02ab093483259811d337e5e8a971