### PR TITLE
Show destination labels on back buttons

### DIFF
--- a/back.js
+++ b/back.js
@@ -1,12 +1,50 @@
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('backBtn');
-  if (btn) {
-    btn.addEventListener('click', () => {
-      if (document.referrer) {
-        window.history.back();
-      } else {
-        window.location.href = 'index.html';
-      }
-    });
+  if (!btn) return;
+
+  const DEFAULT_LABEL = 'Main Menu';
+  const labelMap = {
+    'index.html': 'Main Menu',
+    'drills.html': 'Drills',
+    'scenarios.html': 'Scenarios'
+  };
+
+  const setLabel = text => {
+    btn.textContent = `\u2190 ${text}`;
+  };
+
+  const ref = document.referrer;
+  let mapped = null;
+  if (ref) {
+    try {
+      const url = new URL(ref);
+      const page = url.pathname.split('/').pop();
+      mapped = labelMap[page] || null;
+    } catch {
+      mapped = null;
+    }
   }
+
+  setLabel(mapped || DEFAULT_LABEL);
+
+  if (ref && !mapped) {
+    fetch(ref, { mode: 'same-origin' })
+      .then(res => res.text())
+      .then(html => {
+        const match = html.match(/<title>([^<]*)<\/title>/i);
+        if (match) {
+          const title = match[1].split(' - ')[0].trim();
+          setLabel(title);
+        }
+      })
+      .catch(() => {/* ignore errors, label stays default */});
+  }
+
+  btn.addEventListener('click', () => {
+    if (ref) {
+      window.history.back();
+    } else {
+      window.location.href = 'index.html';
+    }
+  });
 });

--- a/scenarios.html
+++ b/scenarios.html
@@ -8,13 +8,13 @@
 </head>
 <body>
   <div id="listScreen" class="menu-screen">
-    <button id="backBtn">← Back</button>
+    <button id="backBtn">← Main Menu</button>
     <h2>Scenarios</h2>
     <button id="newScenarioBtn">New Scenario</button>
     <div id="scenarioList" class="exercise-list"></div>
   </div>
   <div id="builderScreen" class="menu-screen" style="display:none;">
-    <button id="builderBackBtn">← Back</button>
+    <button id="builderBackBtn">← Scenarios</button>
     <h2>Create Scenario</h2>
     <input id="scenarioTitle" type="text" placeholder="Scenario Title" />
     <div id="sequenceContainer"></div>


### PR DESCRIPTION
## Summary
- Dynamically label back buttons with the destination screen name based on navigation history
- Adjust scenario builder back button to clearly return to the Scenarios list and label main menu navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adaff6e0808325b360bcc498917309