### PR TITLE
Position tap instruction between explanation and dots

### DIFF
--- a/tutorial.html
+++ b/tutorial.html
@@ -9,8 +9,8 @@
 <body class="tutorial-body">
   <button id="backBtn">← Main Menu</button>
   <div id="message">Tap the point.</div>
-  <canvas id="tutorialCanvas" width="500" height="500"></canvas>
   <div id="tapInstruction" style="display:none;">Tap the dots to hear their corresponding sound.</div>
+  <canvas id="tutorialCanvas" width="500" height="500"></canvas>
   <button id="nextBtn" style="display:none;">Next</button>
   <script src="back.js"></script>
   <script type="module" src="tutorial.js"></script>


### PR DESCRIPTION
## Summary
- ensure tap instruction appears before canvas so phrase sits between explanation and colored points

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb1135ac483259d3012d2d4f35a4a