### PR TITLE
Display color-coded feedback below tutorial points

### DIFF
--- a/tutorial.html
+++ b/tutorial.html
@@ -10,7 +10,6 @@
   <button id="backBtn">← Main Menu</button>
   <div id="message">Tap the points.</div>
   <canvas id="tutorialCanvas" width="500" height="500"></canvas>
-  <div id="result"></div>
   <button id="nextBtn">Next</button>
   <script src="back.js"></script>
   <script type="module" src="tutorial.js"></script>

--- a/tutorial.js
+++ b/tutorial.js
@@ -1,10 +1,12 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 
-let canvas, ctx, result, nextBtn;
+let canvas, ctx, nextBtn;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const center = { x: 0, y: 0 };
 const DOT_RADIUS = 10;
 let dots = [];
+let message = '';
+let messageColor = '';
 
 function drawDots() {
   clearCanvas(ctx);
@@ -21,6 +23,12 @@ function drawDots() {
     ctx.arc(d.x, d.y, DOT_RADIUS, 0, Math.PI * 2);
     ctx.fill();
   });
+  if (message) {
+    ctx.font = '24px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillStyle = messageColor;
+    ctx.fillText(message, center.x, y + 40);
+  }
 }
 
 function handleTap(e) {
@@ -29,11 +37,13 @@ function handleTap(e) {
     if (Math.hypot(pos.x - d.x, pos.y - d.y) <= DOT_RADIUS) {
       audioCtx.resume();
       playSound(audioCtx, d.grade);
-      result.textContent = d.grade === 'green'
+      message = d.grade === 'green'
         ? 'Accurate'
         : d.grade === 'yellow'
         ? 'Semi-accurate'
         : 'Inaccurate';
+      messageColor = d.grade === 'yellow' ? 'orange' : d.grade;
+      drawDots();
       break;
     }
   }
@@ -43,7 +53,6 @@ document.addEventListener('DOMContentLoaded', () => {
   canvas = document.getElementById('tutorialCanvas');
   if (!canvas) return;
   ctx = canvas.getContext('2d');
-  result = document.getElementById('result');
   nextBtn = document.getElementById('nextBtn');
   center.x = canvas.width / 2;
   center.y = canvas.height / 2;


### PR DESCRIPTION
## Summary
- show feedback message directly beneath tutorial dots in matching color
- remove extra result element in tutorial layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc2e13ebc8325b73e9cb2cbe3036a