### PR TITLE
feat: add player leaderboard overlay

### DIFF
--- a/angles.html
+++ b/angles.html
@@ -17,5 +17,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="angles.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/complex_shapes.html
+++ b/complex_shapes.html
@@ -21,5 +21,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="complex_shapes.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_contours.html
+++ b/dexterity_contours.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_contours.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_point_drill.html
+++ b/dexterity_point_drill.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_point_drill.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_point_drill_large.html
+++ b/dexterity_point_drill_large.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_point_drill.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_point_drill_small.html
+++ b/dexterity_point_drill_small.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_point_drill.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_thick_contours.html
+++ b/dexterity_thick_contours.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_thick_contours.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_thick_lines.html
+++ b/dexterity_thick_lines.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_thick_lines.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_thin_lines.html
+++ b/dexterity_thin_lines.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="dexterity_thin_lines.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/inch_warmup.html
+++ b/inch_warmup.html
@@ -17,5 +17,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="inch_warmup.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,70 @@
+(function() {
+  function getPlayerName() {
+    let name = localStorage.getItem('playerName');
+    if (!name) {
+      name = prompt('Enter your name');
+      if (!name) name = 'Player';
+      localStorage.setItem('playerName', name);
+    }
+    return name;
+  }
+
+  function updateLeaderboard(key, score) {
+    const name = getPlayerName();
+    const storeKey = 'leaderboard_' + key;
+    const data = JSON.parse(localStorage.getItem(storeKey)) || {};
+    const current = data[name] || 0;
+    if (score > current) {
+      data[name] = score;
+      localStorage.setItem(storeKey, JSON.stringify(data));
+    }
+  }
+
+  function showLeaderboard(key) {
+    const storeKey = 'leaderboard_' + key;
+    const data = JSON.parse(localStorage.getItem(storeKey)) || {};
+    const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+    const overlay = document.createElement('div');
+    overlay.className = 'leaderboard-overlay';
+    const inner = document.createElement('div');
+    inner.className = 'leaderboard';
+    const title = document.createElement('h2');
+    title.textContent = 'Leaderboard';
+    inner.appendChild(title);
+    entries.forEach(([n, s]) => {
+      const p = document.createElement('p');
+      p.textContent = `${n}: ${s}`;
+      inner.appendChild(p);
+    });
+    const close = document.createElement('p');
+    close.textContent = 'Click to close';
+    close.className = 'leaderboard-close';
+    inner.appendChild(close);
+    overlay.appendChild(inner);
+    overlay.addEventListener('click', () => overlay.remove());
+    document.body.appendChild(overlay);
+  }
+
+  function handleScore(key, score) {
+    updateLeaderboard(key, score);
+    showLeaderboard(key);
+  }
+
+  window.leaderboard = { handleScore };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const resultEl = document.querySelector('.score');
+    if (!resultEl) return;
+    const canvas = document.querySelector('canvas[data-score-key]');
+    const key = canvas ? canvas.dataset.scoreKey : 'default';
+    const observer = new MutationObserver(() => {
+      const m = resultEl.textContent.match(/Score:\s*(\d+)/);
+      if (m) {
+        const score = parseInt(m[1], 10);
+        handleScore(key, score);
+        observer.disconnect();
+      }
+    });
+    observer.observe(resultEl, { childList: true });
+  });
+})();

--- a/observation.html
+++ b/observation.html
@@ -41,5 +41,6 @@
 
   <script src="back.js"></script>
   <script type="module" src="observation.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="point_drill_01.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="point_drill_025.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -16,5 +16,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="point_drill_05.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/quadrilaterals.html
+++ b/quadrilaterals.html
@@ -21,5 +21,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="quadrilaterals.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -12,7 +12,7 @@
     <h2 id="scenarioTitle">Scenario</h2>
     <button id="startBtn">Start Challenge</button>
     <div class="play-area">
-      <canvas id="gameCanvas" width="500" height="500"></canvas>
+      <canvas id="gameCanvas" width="500" height="500" data-score-key="scenario_play"></canvas>
       <div class="scoreboard">
         <p>Avg Error: <span id="avgError">0.0</span> px</p>
         <p>Green: <span id="greenCount">0</span></p>
@@ -72,5 +72,6 @@
   <script src="back.js"></script>
   <script type="module" src="app.js"></script>
   <script type="module" src="scenario.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/shape_trainer.html
+++ b/shape_trainer.html
@@ -74,5 +74,6 @@
 
   <script src="back.js"></script>
   <script type="module" src="app.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -429,3 +429,29 @@ h2, h1 { margin: 10px 0; }
   align-self: flex-start;
   margin: 10px;
 }
+.leaderboard-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.leaderboard {
+  background: #222;
+  padding: 20px;
+  border-radius: 8px;
+  color: #fff;
+  text-align: center;
+}
+
+.leaderboard-close {
+  margin-top: 10px;
+  font-size: 0.9em;
+  opacity: 0.7;
+}

--- a/triangles.html
+++ b/triangles.html
@@ -21,5 +21,6 @@
   </div>
   <script src="back.js"></script>
   <script type="module" src="triangles.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/tutorial.html
+++ b/tutorial.html
@@ -13,5 +13,6 @@
   <button id="nextBtn">Next</button>
   <script src="back.js"></script>
   <script type="module" src="tutorial.js"></script>
+  <script src="leaderboard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add global `leaderboard.js` that tracks each player's high scores and shows an overlay
- include leaderboard script in all drill pages and tag scenario canvas for tracking
- style leaderboard overlay for full-screen display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af779c25008325871526a06d96a0ea