### PR TITLE
Tone down difficulty tag colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -356,15 +356,15 @@ h2, h1 { margin: 10px 0; }
 }
 
 .difficulty-beginner {
-  background-color: #4CAF50;
+  background-color: #757575;
 }
 
 .difficulty-adept {
-  background-color: #FF9800;
+  background-color: #616161;
 }
 
 .difficulty-expert {
-  background-color: #F44336;
+  background-color: #424242;
 }
 .strikes {
   display: flex;


### PR DESCRIPTION
## Summary
- neutralize the difficulty tag backgrounds with gray tones for a calmer look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af7873e6608325b642f43e2153b5d5