### PR TITLE
Simplify leaderboard overlay

### DIFF
--- a/leaderboard.js
+++ b/leaderboard.js
@@ -28,18 +28,21 @@
     const overlay = document.createElement('div');
     overlay.className = 'leaderboard-overlay';
 
-    const inner = document.createElement('div');
-    inner.className = 'leaderboard';
-
     const canvas = document.querySelector('canvas');
     if (canvas) {
-      inner.style.width = canvas.offsetWidth * 0.9 + 'px';
-      inner.style.height = canvas.offsetHeight * 0.9 + 'px';
+      const rect = canvas.getBoundingClientRect();
+      const width = rect.width * 0.9;
+      const height = rect.height * 0.9;
+      overlay.style.position = 'absolute';
+      overlay.style.width = width + 'px';
+      overlay.style.height = height + 'px';
+      overlay.style.top = rect.top + window.scrollY + (rect.height - height) / 2 + 'px';
+      overlay.style.left = rect.left + window.scrollX + (rect.width - width) / 2 + 'px';
     }
 
     const title = document.createElement('h2');
     title.textContent = 'Leaderboard';
-    inner.appendChild(title);
+    overlay.appendChild(title);
 
     const list = document.createElement('div');
     list.className = 'leaderboard-list';
@@ -51,7 +54,7 @@
       list.appendChild(p);
     });
 
-    inner.appendChild(list);
+    overlay.appendChild(list);
 
     const buttons = document.createElement('div');
     buttons.className = 'leaderboard-buttons';
@@ -68,9 +71,8 @@
 
     buttons.appendChild(retry);
     buttons.appendChild(back);
-    inner.appendChild(buttons);
+    overlay.appendChild(buttons);
 
-    overlay.appendChild(inner);
     document.body.appendChild(overlay);
   }
 

--- a/style.css
+++ b/style.css
@@ -430,27 +430,19 @@ h2, h1 { margin: 10px 0; }
   margin: 10px;
 }
 .leaderboard-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.leaderboard {
-  background: #222;
-  padding: 20px;
-  border-radius: 8px;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.7);
   color: #fff;
   text-align: center;
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  border-radius: 8px;
   max-height: 90%;
+  z-index: 1000;
+  box-sizing: border-box;
 }
 
 .leaderboard-list {


### PR DESCRIPTION
## Summary
- Combine leaderboard overlay into single semi-transparent box overlaying the canvas
- Style overlay box to house scores and actions directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05a49b2b88325b292d647d5de31dc