### PR TITLE
Allow point drill grading tones to be interrupted

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -30,29 +30,53 @@ export function clearCanvas(ctx) {
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 }
 
+let currentSound = null;
+
 export function playSound(audioCtx, grade) {
+  // Stop any sound that is already playing so a new grading tone can
+  // start immediately in response to fresh pointer input.
+  if (currentSound) {
+    try {
+      currentSound.osc.onended = null;
+      currentSound.osc.stop();
+    } catch (e) {
+      // ignore errors if the oscillator is already stopped
+    }
+    currentSound.gain.disconnect();
+    currentSound = null;
+  }
+
   const osc = audioCtx.createOscillator();
   const gain = audioCtx.createGain();
   osc.connect(gain).connect(audioCtx.destination);
   const now = audioCtx.currentTime;
+  let duration;
   if (grade === 'green') {
     osc.frequency.setValueAtTime(800, now);
     gain.gain.setValueAtTime(1, now);
     gain.gain.exponentialRampToValueAtTime(0.001, now + 0.1);
-    osc.start(now);
-    osc.stop(now + 0.1);
+    duration = 0.1;
   } else if (grade === 'yellow') {
     osc.frequency.setValueAtTime(400, now);
     gain.gain.setValueAtTime(0.6, now);
     gain.gain.exponentialRampToValueAtTime(0.001, now + 0.15);
-    osc.start(now);
-    osc.stop(now + 0.15);
+    duration = 0.15;
   } else {
     osc.frequency.setValueAtTime(200, now);
     osc.frequency.linearRampToValueAtTime(100, now + 0.3);
     gain.gain.setValueAtTime(0.7, now);
     gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
-    osc.start(now);
-    osc.stop(now + 0.3);
+    duration = 0.3;
   }
+
+  osc.onended = () => {
+    gain.disconnect();
+    if (currentSound && currentSound.osc === osc) {
+      currentSound = null;
+    }
+  };
+
+  osc.start(now);
+  osc.stop(now + duration);
+  currentSound = { osc, gain };
 }


### PR DESCRIPTION
## Summary
- stop any existing oscillator before starting a new grading tone
- keep pointer input responsive by letting new taps interrupt sounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b05b1be70c83259a9247c3f70b7a78