### PR TITLE
Fix delayed input in point dexterity drills

### DIFF
--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -23,9 +23,9 @@ function drawTarget() {
   ctx.beginPath();
   ctx.arc(target.x, target.y, 5, 0, Math.PI * 2);
   ctx.fill();
+  awaitingClick = true;
   setTimeout(() => {
     clearCanvas(ctx);
-    awaitingClick = true;
   }, 100);
 }
 

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -23,9 +23,9 @@ function drawTarget() {
   ctx.beginPath();
   ctx.arc(target.x, target.y, 5, 0, Math.PI * 2);
   ctx.fill();
+  awaitingClick = true;
   setTimeout(() => {
     clearCanvas(ctx);
-    awaitingClick = true;
   }, 250);
 }
 

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -23,9 +23,9 @@ function drawTarget() {
   ctx.beginPath();
   ctx.arc(target.x, target.y, 5, 0, Math.PI * 2);
   ctx.fill();
+  awaitingClick = true;
   setTimeout(() => {
     clearCanvas(ctx);
-    awaitingClick = true;
   }, 500);
 }
 


### PR DESCRIPTION
## Summary
- allow taps while the target is visible in point drills by enabling input immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06121b2e08325ada9bd03edd31ac4