### PR TITLE
Overlay start buttons on drill canvases

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -1,4 +1,5 @@
 import { playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 const canvas = document.getElementById('angleCanvas');
 const ctx = canvas.getContext('2d');
@@ -45,6 +46,7 @@ function createOptions() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   remainingAngles = [];
   for (let a = step; a <= 180; a += step) remainingAngles.push(a);
@@ -120,7 +122,6 @@ function onSelect(e) {
     if (done) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       result.textContent = `You got ${correct} out of ${total} correct.`;
-      startBtn.disabled = false;
       playing = false;
     } else {
       nextAngle();
@@ -143,7 +144,6 @@ function onSelect(e) {
     if (done) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       result.textContent = `You got ${correct} out of ${total} correct.`;
-      startBtn.disabled = false;
       playing = false;
     } else {
       nextAngle();
@@ -159,6 +159,7 @@ function nextAngle() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  overlayStartButton(canvas, startBtn);
   createOptions();
   const title = `Angles (${step}\u00B0 increments)`;
   document.querySelector('h2').textContent = title;

--- a/complex_shapes.js
+++ b/complex_shapes.js
@@ -1,5 +1,6 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { generateShape, distancePointToSegment } from './geometry.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -231,7 +232,6 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  startBtn.disabled = false;
   result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'shape' : 'shapes'}.`;
 }
 
@@ -247,6 +247,7 @@ function startShape() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   startBtn.disabled = true;
@@ -344,6 +345,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   strikeElems = Array.from(document.querySelectorAll('#strikes .strike'));
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result;
 let playing = false;
@@ -98,6 +99,7 @@ function drawTargets() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   score = 0;
@@ -119,7 +121,6 @@ function endGame() {
     localStorage.setItem(scoreKey, high.toString());
   }
   result.textContent = `Score: ${score} (Best: ${high})`;
-  startBtn.disabled = false;
 }
 
 function projectPointToCurve(p, curve) {
@@ -246,6 +247,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result;
 let playing = false;
@@ -30,6 +31,7 @@ function drawTargets() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   score = 0;
@@ -51,7 +53,6 @@ function endGame() {
     localStorage.setItem(scoreKey, high.toString());
   }
   result.textContent = `Score: ${score} (Best: ${high})`;
-  startBtn.disabled = false;
 }
 
 function pointerDown(e) {
@@ -79,6 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   targetRadius = Number(canvas.dataset.radius) || targetRadius;
   gradingTolerance = Number(canvas.dataset.tolerance) || targetRadius;

--- a/dexterity_thick_contours.js
+++ b/dexterity_thick_contours.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result;
 let playing = false;
@@ -98,6 +99,7 @@ function drawTargets() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   score = 0;
@@ -119,7 +121,6 @@ function endGame() {
     localStorage.setItem(scoreKey, high.toString());
   }
   result.textContent = `Score: ${score} (Best: ${high})`;
-  startBtn.disabled = false;
 }
 
 function projectPointToCurve(p, curve) {
@@ -246,6 +247,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result;
 let playing = false;
@@ -63,6 +64,7 @@ function drawTargets() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   score = 0;
@@ -84,7 +86,6 @@ function endGame() {
     localStorage.setItem(scoreKey, high.toString());
   }
   result.textContent = `Score: ${score} (Best: ${high})`;
-  startBtn.disabled = false;
 }
 
 function projectPointToSegment(p, seg) {
@@ -190,6 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 

--- a/dexterity_thin_lines.js
+++ b/dexterity_thin_lines.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result;
 let playing = false;
@@ -63,6 +64,7 @@ function drawTargets() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   score = 0;
@@ -84,7 +86,6 @@ function endGame() {
     localStorage.setItem(scoreKey, high.toString());
   }
   result.textContent = `Score: ${score} (Best: ${high})`;
-  startBtn.disabled = false;
 }
 
 function projectPointToSegment(p, seg) {
@@ -190,6 +191,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result, ppiInput;
 
@@ -28,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   ppiInput = document.getElementById('ppiInput');
 
@@ -153,6 +155,7 @@ function pointerUp(e) {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
@@ -170,6 +173,5 @@ function endGame() {
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(3)} in | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
-  startBtn.disabled = false;
 }
 

--- a/line_segments.js
+++ b/line_segments.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -81,7 +82,6 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  startBtn.disabled = false;
   result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'segment' : 'segments'}.`;
 }
 
@@ -163,6 +163,7 @@ function startSegment() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   startBtn.disabled = true;
@@ -179,6 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   strikeElems = Array.from(document.querySelectorAll('#strikes .strike'));
   canvas.addEventListener('pointerdown', pointerDown);

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
 
@@ -76,6 +77,7 @@ function pointerDown(e) {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
@@ -94,7 +96,6 @@ function endGame() {
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
-  startBtn.disabled = false;
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -123,6 +124,11 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  wrapper.appendChild(startBtn);
+  startBtn.style.position = 'absolute';
+  startBtn.style.top = '50%';
+  startBtn.style.left = '50%';
+  startBtn.style.transform = 'translate(-50%, -50%)';
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
 
@@ -76,6 +77,7 @@ function pointerDown(e) {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
@@ -94,7 +96,6 @@ function endGame() {
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
-  startBtn.disabled = false;
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -123,6 +124,11 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  wrapper.appendChild(startBtn);
+  startBtn.style.position = 'absolute';
+  startBtn.style.top = '50%';
+  startBtn.style.left = '50%';
+  startBtn.style.transform = 'translate(-50%, -50%)';
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
 
@@ -76,6 +77,7 @@ function pointerDown(e) {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
@@ -94,7 +96,6 @@ function endGame() {
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
-  startBtn.disabled = false;
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -125,6 +126,11 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  wrapper.appendChild(startBtn);
+  startBtn.style.position = 'absolute';
+  startBtn.style.top = '50%';
+  startBtn.style.left = '50%';
+  startBtn.style.transform = 'translate(-50%, -50%)';
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -1,5 +1,6 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { generateShape } from './geometry.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -74,7 +75,6 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  startBtn.disabled = false;
   result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'shape' : 'shapes'}.`;
 }
 
@@ -156,6 +156,7 @@ function startQuadrilateral() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   startBtn.disabled = true;
@@ -172,6 +173,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   strikeElems = Array.from(document.querySelectorAll('#strikes .strike'));
   canvas.addEventListener('pointerdown', pointerDown);

--- a/scenario.js
+++ b/scenario.js
@@ -20,6 +20,7 @@ import {
   setViewTimer
 } from './app.js';
 import { getScenario } from './scenarios.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let scenarioTimer = null;
 let scoreSummary = { totalDist: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
@@ -206,6 +207,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const startBtn = document.getElementById('startBtn');
   if (startBtn) {
+    overlayStartButton(canvas, startBtn);
     const params = new URLSearchParams(window.location.search);
     scenarioName = params.get('name') || 'default';
     const titleEl = document.getElementById('scenarioTitle');
@@ -237,6 +239,7 @@ document.addEventListener('DOMContentLoaded', () => {
       toggleThreshold();
     }
     startBtn.addEventListener('click', () => {
+      hideStartButton(startBtn);
       result.textContent = '';
       startScenario();
     });

--- a/src/start-button.js
+++ b/src/start-button.js
@@ -1,0 +1,16 @@
+export function overlayStartButton(canvas, startBtn) {
+  const wrapper = document.createElement('div');
+  wrapper.style.position = 'relative';
+  canvas.parentNode.insertBefore(wrapper, canvas);
+  wrapper.appendChild(canvas);
+  wrapper.appendChild(startBtn);
+  startBtn.style.position = 'absolute';
+  startBtn.style.top = '50%';
+  startBtn.style.left = '50%';
+  startBtn.style.transform = 'translate(-50%, -50%)';
+}
+
+export function hideStartButton(startBtn) {
+  startBtn.style.display = 'none';
+}
+

--- a/triangles.js
+++ b/triangles.js
@@ -1,4 +1,5 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { overlayStartButton, hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -90,7 +91,6 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  startBtn.disabled = false;
   result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'shape' : 'shapes'}.`;
 }
 
@@ -172,6 +172,7 @@ function startTriangle() {
 }
 
 function startGame() {
+  hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
   startBtn.disabled = true;
@@ -188,6 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!canvas) return;
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
+  overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
   strikeElems = Array.from(document.querySelectorAll('#strikes .strike'));
   canvas.addEventListener('pointerdown', pointerDown);


### PR DESCRIPTION
## Summary
- overlay start buttons directly over canvases for drills
- hide start buttons once drills start and keep them hidden when drills end

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06151ea588325bd3e70ffff495f5e