### PR TITLE
Add hundredth-second countdown timer to timed drills

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { getCanvasPos } from '../src/utils.js';
+import { getCanvasPos, startCountdown } from '../src/utils.js';
+import { jest } from '@jest/globals';
 
 describe('getCanvasPos', () => {
   test('uses offset coordinates for mouse input', () => {
@@ -25,5 +26,20 @@ describe('getCanvasPos', () => {
     const e = { clientX: 60, clientY: 70, offsetX: 0, offsetY: 0, pointerType: 'touch' };
     const pos = getCanvasPos(canvas, e);
     expect(pos).toEqual({ x: 100, y: 100 });
+  });
+
+  test('startCountdown updates element and calls callback', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    const el = document.createElement('div');
+    const cb = jest.fn();
+    startCountdown(100, el, cb);
+    expect(el.textContent).toBe('0.10');
+    jest.advanceTimersByTime(50);
+    expect(parseFloat(el.textContent)).toBeCloseTo(0.05, 2);
+    jest.advanceTimersByTime(50);
+    expect(el.textContent).toBe('0.00');
+    expect(cb).toHaveBeenCalled();
+    jest.useRealTimers();
   });
 });

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -1,10 +1,10 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerEl;
 let playing = false;
 let targets = [];
 let score = 0;
-let gameTimer = null;
+let stopTimer = null;
 let scoreKey = 'dexterity_contours';
 
 let drawing = false;
@@ -105,13 +105,16 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomCurve(), randomCurve()];
   drawTargets();
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -247,6 +250,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  canvas.parentNode.insertBefore(timerEl, canvas);
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -1,10 +1,10 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerEl;
 let playing = false;
 let targets = [];
 let score = 0;
-let gameTimer = null;
+let stopTimer = null;
 let targetRadius = 5;
 let gradingTolerance = 5;
 let scoreKey = 'dexterity_point_drill';
@@ -37,13 +37,16 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomTarget(), randomTarget()];
   drawTargets();
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -80,6 +83,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  canvas.parentNode.insertBefore(timerEl, canvas);
   targetRadius = Number(canvas.dataset.radius) || targetRadius;
   gradingTolerance = Number(canvas.dataset.tolerance) || targetRadius;
   scoreKey = canvas.dataset.scoreKey || scoreKey;

--- a/dexterity_thick_contours.js
+++ b/dexterity_thick_contours.js
@@ -1,10 +1,10 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerEl;
 let playing = false;
 let targets = [];
 let score = 0;
-let gameTimer = null;
+let stopTimer = null;
 let scoreKey = 'dexterity_thick_contours';
 
 let drawing = false;
@@ -105,13 +105,16 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomCurve(), randomCurve()];
   drawTargets();
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -247,6 +250,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  canvas.parentNode.insertBefore(timerEl, canvas);
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -1,10 +1,10 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerEl;
 let playing = false;
 let targets = [];
 let score = 0;
-let gameTimer = null;
+let stopTimer = null;
 let scoreKey = 'dexterity_thick_lines';
 
 let drawing = false;
@@ -70,13 +70,16 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomLine(), randomLine()];
   drawTargets();
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -191,6 +194,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  canvas.parentNode.insertBefore(timerEl, canvas);
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_thin_lines.js
+++ b/dexterity_thin_lines.js
@@ -1,10 +1,10 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerEl;
 let playing = false;
 let targets = [];
 let score = 0;
-let gameTimer = null;
+let stopTimer = null;
 let scoreKey = 'dexterity_thin_lines';
 
 let drawing = false;
@@ -70,13 +70,16 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomLine(), randomLine()];
   drawTargets();
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -191,6 +194,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ctx = canvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  canvas.parentNode.insertBefore(timerEl, canvas);
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/inch_warmup.js
+++ b/inch_warmup.js
@@ -1,12 +1,12 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, startBtn, result, ppiInput;
+let canvas, ctx, startBtn, result, ppiInput, timerEl;
 
 let playing = false;
 let drawing = false;
 let startPos = null;
 let endTime = 0;
-let gameTimer = null;
+let stopTimer = null;
 let stats = null;
 let currentArrow = null;
 let path = [];
@@ -30,6 +30,10 @@ document.addEventListener('DOMContentLoaded', () => {
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
   ppiInput = document.getElementById('ppiInput');
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  canvas.parentNode.insertBefore(timerEl, canvas);
 
   ppiInput.value = (PPI * DPR).toFixed(1);
   ppiInput.addEventListener('input', () => {
@@ -159,14 +163,17 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
   drawArrow();
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(3)} in | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -1,12 +1,12 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
+let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerEl;
 
 let playing = false;
 let awaitingClick = false;
 let target = null;
 let endTime = 0;
-let gameTimer = null;
+let stopTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -83,14 +83,17 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
   drawTarget();
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
@@ -123,6 +126,11 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  wrapper.parentNode.insertBefore(timerEl, wrapper);
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -1,12 +1,12 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
+let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerEl;
 
 let playing = false;
 let awaitingClick = false;
 let target = null;
 let endTime = 0;
-let gameTimer = null;
+let stopTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -83,14 +83,17 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
   drawTarget();
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
@@ -123,6 +126,11 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  wrapper.parentNode.insertBefore(timerEl, wrapper);
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -1,12 +1,12 @@
-import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
+import { getCanvasPos, clearCanvas, playSound, startCountdown } from './src/utils.js';
 
-let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
+let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerEl;
 
 let playing = false;
 let awaitingClick = false;
 let target = null;
 let endTime = 0;
-let gameTimer = null;
+let stopTimer = null;
 let stats = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -83,14 +83,17 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
-  gameTimer = setTimeout(endGame, 60000);
+  stopTimer = startCountdown(60000, timerEl, endGame);
   drawTarget();
 }
 
 function endGame() {
   if (!playing) return;
   playing = false;
-  clearTimeout(gameTimer);
+  if (stopTimer) {
+    stopTimer();
+    stopTimer = null;
+  }
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
@@ -125,6 +128,11 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+
+  timerEl = document.createElement('div');
+  timerEl.className = 'timer';
+  timerEl.textContent = '60.00';
+  wrapper.parentNode.insertBefore(timerEl, wrapper);
 
   canvas.addEventListener('pointerdown', pointerDown);
   startBtn.addEventListener('click', startGame);

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,3 +80,22 @@ export function playSound(audioCtx, grade) {
   osc.stop(now + duration);
   currentSound = { osc, gain };
 }
+
+export function startCountdown(durationMs, display, onFinish) {
+  const start = Date.now();
+  display.textContent = (durationMs / 1000).toFixed(2);
+  const intervalId = setInterval(() => {
+    const elapsed = Date.now() - start;
+    const remaining = Math.max(0, durationMs - elapsed);
+    display.textContent = (remaining / 1000).toFixed(2);
+  }, 10);
+  const timeoutId = setTimeout(() => {
+    clearInterval(intervalId);
+    display.textContent = '0.00';
+    if (onFinish) onFinish();
+  }, durationMs);
+  return () => {
+    clearInterval(intervalId);
+    clearTimeout(timeoutId);
+  };
+}

--- a/style.css
+++ b/style.css
@@ -134,6 +134,12 @@ canvas {
   font-weight: bold;
   min-height: 1.5em;
 }
+.timer {
+  text-align: center;
+  font-weight: bold;
+  font-family: monospace;
+  min-height: 1.5em;
+}
 .switch-label-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- implement reusable `startCountdown` to update timer display every 0.01s
- show countdown above canvas in all timed drills with monospace styling
- cover countdown behavior with new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b061c7e9e08325865c895bad16e2c9