### PR TITLE
Add countdown timer to dexterity drills

### DIFF
--- a/dexterity_contours.html
+++ b/dexterity_contours.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Contours</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_contours"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -1,12 +1,14 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_contours';
+let stopTimer = null;
 
 let drawing = false;
 let activeTarget = null;
@@ -107,6 +109,7 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomCurve(), randomCurve()];
   drawTargets();
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
 }
 
@@ -114,6 +117,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -249,6 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
   startBtn = document.getElementById('startBtn');
   overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_point_drill.html
+++ b/dexterity_point_drill.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Medium Points</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-radius="5" data-tolerance="5" data-score-key="dexterity_point_drill"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -1,7 +1,8 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let score = 0;
@@ -9,6 +10,7 @@ let gameTimer = null;
 let targetRadius = 5;
 let gradingTolerance = 5;
 let scoreKey = 'dexterity_point_drill';
+let stopTimer = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -39,6 +41,7 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomTarget(), randomTarget()];
   drawTargets();
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
 }
 
@@ -46,6 +49,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -82,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
   startBtn = document.getElementById('startBtn');
   overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   targetRadius = Number(canvas.dataset.radius) || targetRadius;
   gradingTolerance = Number(canvas.dataset.tolerance) || targetRadius;
   scoreKey = canvas.dataset.scoreKey || scoreKey;

--- a/dexterity_point_drill_large.html
+++ b/dexterity_point_drill_large.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Large Points</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-radius="10" data-tolerance="10" data-score-key="dexterity_point_drill_large"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_point_drill_small.html
+++ b/dexterity_point_drill_small.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Small Points</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-radius="3" data-tolerance="3" data-score-key="dexterity_point_drill_small"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_thick_contours.html
+++ b/dexterity_thick_contours.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Thick Contours</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thick_contours"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_thick_contours.js
+++ b/dexterity_thick_contours.js
@@ -1,12 +1,14 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_thick_contours';
+let stopTimer = null;
 
 let drawing = false;
 let activeTarget = null;
@@ -107,6 +109,7 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomCurve(), randomCurve()];
   drawTargets();
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
 }
 
@@ -114,6 +117,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -249,6 +253,7 @@ document.addEventListener('DOMContentLoaded', () => {
   startBtn = document.getElementById('startBtn');
   overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_thick_lines.html
+++ b/dexterity_thick_lines.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Thick Lines</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thick_lines"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -1,12 +1,14 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_thick_lines';
+let stopTimer = null;
 
 let drawing = false;
 let activeTarget = null;
@@ -72,6 +74,7 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomLine(), randomLine()];
   drawTargets();
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
 }
 
@@ -79,6 +82,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -193,6 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
   startBtn = document.getElementById('startBtn');
   overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/dexterity_thin_lines.html
+++ b/dexterity_thin_lines.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Thin Lines</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thin_lines"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/dexterity_thin_lines.js
+++ b/dexterity_thin_lines.js
@@ -1,12 +1,14 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, startBtn, result;
+let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_thin_lines';
+let stopTimer = null;
 
 let drawing = false;
 let activeTarget = null;
@@ -72,6 +74,7 @@ function startGame() {
   startBtn.disabled = true;
   targets = [randomLine(), randomLine()];
   drawTargets();
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
 }
 
@@ -79,6 +82,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   let high = parseInt(localStorage.getItem(scoreKey)) || 0;
   if (score > high) {
@@ -193,6 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
   startBtn = document.getElementById('startBtn');
   overlayStartButton(canvas, startBtn);
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
 
   canvas.addEventListener('pointerdown', pointerDown);

--- a/src/countdown.js
+++ b/src/countdown.js
@@ -1,0 +1,17 @@
+export function startCountdown(element, duration) {
+  const start = performance.now();
+  function update() {
+    const elapsed = performance.now() - start;
+    const remaining = Math.max(0, duration - elapsed);
+    element.textContent = (remaining / 1000).toFixed(2);
+    if (remaining <= 0) {
+      clearInterval(timerId);
+    }
+  }
+  update();
+  const timerId = setInterval(update, 10);
+  return () => {
+    clearInterval(timerId);
+    element.textContent = '0.00';
+  };
+}

--- a/style.css
+++ b/style.css
@@ -134,6 +134,11 @@ canvas {
   font-weight: bold;
   min-height: 1.5em;
 }
+.timer {
+  text-align: center;
+  font-size: 24px;
+  margin: 10px 0;
+}
 .switch-label-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- show a 100th-second countdown above each dexterity drill canvas
- centralize timer logic in new `startCountdown` utility
- style timer element for clear display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b070f072fc8325ad4dabbc9d562b52