### PR TITLE
feat: add scoring for memorization drills

### DIFF
--- a/angles.html
+++ b/angles.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Angles (5° increments)</h2>
     <button id="startBtn">Start</button>
-    <canvas id="angleCanvas" width="500" height="500"></canvas>
+    <canvas id="angleCanvas" width="500" height="500" data-score-key="angles_5"></canvas>
     <div id="angleOptions" class="angle-options"></div>
     <p class="score" id="angleResult"></p>
   </div>

--- a/angles.js
+++ b/angles.js
@@ -8,6 +8,9 @@ const result = document.getElementById('angleResult');
 const startBtn = document.getElementById('startBtn');
 const step = parseInt(new URLSearchParams(window.location.search).get('step')) || 5;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+let startTime = 0;
+let scoreKey = `angles_${step}`;
+canvas.dataset.scoreKey = scoreKey;
 
 let rotation = 0;
 let centerX = 0;
@@ -62,6 +65,8 @@ function startGame() {
   });
   startBtn.disabled = true;
   playing = true;
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
+  startTime = performance.now();
   nextAngle();
 }
 
@@ -121,7 +126,7 @@ function onSelect(e) {
     const done = remainingAngles.length === 0;
     if (done) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      result.textContent = `You got ${correct} out of ${total} correct.`;
+      finishGame();
       playing = false;
     } else {
       nextAngle();
@@ -143,7 +148,7 @@ function onSelect(e) {
   setTimeout(() => {
     if (done) {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      result.textContent = `You got ${correct} out of ${total} correct.`;
+      finishGame();
       playing = false;
     } else {
       nextAngle();
@@ -156,6 +161,17 @@ function nextAngle() {
   const idx = Math.floor(Math.random() * remainingAngles.length);
   currentAngle = remainingAngles[idx];
   drawAngle(currentAngle);
+}
+
+function finishGame() {
+  const elapsed = (performance.now() - startTime) / 1000;
+  const score = elapsed > 0 ? Math.round((correct * correct * 100) / elapsed) : 0;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `You got ${correct} out of ${total} correct. Score: ${score} (Best: ${high})`;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/complex_shapes.html
+++ b/complex_shapes.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Complex Shapes</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="complex_shapes"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>

--- a/complex_shapes.js
+++ b/complex_shapes.js
@@ -17,6 +17,8 @@ let correctSamples = 0;
 let totalSamples = 0;
 let strikes = 0;
 let shapesCompleted = 0;
+let totalAttempts = 0;
+let scoreKey = 'complex_shapes';
 
 const SHOW_COLOR_TIME = 500;
 const NEW_SHAPE_DELAY = 3000;
@@ -232,7 +234,14 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'shape' : 'shapes'}.`;
+  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
+  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function startShape() {
@@ -255,6 +264,8 @@ function startGame() {
   attemptCount = 0;
   strikes = 0;
   shapesCompleted = 0;
+  totalAttempts = 0;
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startShape();
 }
@@ -312,6 +323,7 @@ function pointerUp() {
 
   if (accuracy >= 0.9) {
     shapesCompleted++;
+    totalAttempts += attemptCount;
     result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
     setTimeout(() => {
       attemptGreyed = true;

--- a/drills.html
+++ b/drills.html
@@ -12,7 +12,7 @@
     <h2>Drills</h2>
     <input id="searchInput" type="text" placeholder="Search drills..." />
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="line_segments.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="line_segments.html" data-difficulty="Beginner" data-score-key="line_segments">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Lines</span>
@@ -24,7 +24,7 @@
           <p>Memorize line segment endpoints.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner" data-score-key="triangles">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Shapes</span>
@@ -36,7 +36,7 @@
           <p>Memorize triangle vertices.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept" data-score-key="quadrilaterals">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Shapes</span>
@@ -48,7 +48,7 @@
           <p>Memorize quadrilateral vertices.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">
+      <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert" data-score-key="complex_shapes">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Shapes</span>
@@ -60,7 +60,7 @@
           <p>Memorize mixed curved and straight shapes.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="angles.html" data-difficulty="Expert">
+      <div class="exercise-item" data-link="angles.html" data-difficulty="Expert" data-score-key="angles_5">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Angles</span>
@@ -72,7 +72,7 @@
           <p>Guess randomly oriented angles in 5° steps.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="angles.html?step=10" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="angles.html?step=10" data-difficulty="Beginner" data-score-key="angles_10">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Angles</span>

--- a/line_segments.html
+++ b/line_segments.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Line Segments</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="line_segments"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>

--- a/line_segments.js
+++ b/line_segments.js
@@ -11,6 +11,8 @@ let guessesGreyed = false;
 let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
+let totalAttempts = 0;
+let scoreKey = 'line_segments';
 let attemptHasRed = false;
 
 const SHOW_COLOR_TIME = 500;
@@ -82,7 +84,14 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'segment' : 'segments'}.`;
+  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
+  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function finishCycle() {
@@ -92,6 +101,7 @@ function finishCycle() {
   drawSegment(true);
   if (success) {
     shapesCompleted++;
+    totalAttempts += attemptCount;
     result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
     setTimeout(() => {
       guessesGreyed = true;
@@ -171,6 +181,8 @@ function startGame() {
   attemptCount = 0;
   strikes = 0;
   shapesCompleted = 0;
+  totalAttempts = 0;
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startSegment();
 }

--- a/quadrilaterals.html
+++ b/quadrilaterals.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Quadrilaterals</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="quadrilaterals"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>

--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -12,6 +12,8 @@ let guessesGreyed = false;
 let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
+let totalAttempts = 0;
+let scoreKey = 'quadrilaterals';
 let attemptHasRed = false;
 
 const SHOW_COLOR_TIME = 500;
@@ -75,7 +77,14 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'shape' : 'shapes'}.`;
+  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
+  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function finishCycle() {
@@ -85,6 +94,7 @@ function finishCycle() {
   drawQuadrilateral(true);
   if (success) {
     shapesCompleted++;
+    totalAttempts += attemptCount;
     result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
     setTimeout(() => {
       guessesGreyed = true;
@@ -164,6 +174,8 @@ function startGame() {
   attemptCount = 0;
   strikes = 0;
   shapesCompleted = 0;
+  totalAttempts = 0;
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startQuadrilateral();
 }

--- a/triangles.html
+++ b/triangles.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Triangles</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="triangles"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>

--- a/triangles.js
+++ b/triangles.js
@@ -11,6 +11,8 @@ let guessesGreyed = false;
 let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
+let totalAttempts = 0;
+let scoreKey = 'triangles';
 let attemptHasRed = false;
 
 const SHOW_COLOR_TIME = 500;
@@ -91,7 +93,14 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  result.textContent = `Struck out! You completed ${shapesCompleted} ${shapesCompleted === 1 ? 'shape' : 'shapes'}.`;
+  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
+  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
+  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
+  if (score > high) {
+    high = score;
+    localStorage.setItem(scoreKey, high.toString());
+  }
+  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function finishCycle() {
@@ -101,6 +110,7 @@ function finishCycle() {
   drawTriangle(true);
   if (success) {
     shapesCompleted++;
+    totalAttempts += attemptCount;
     result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
     setTimeout(() => {
       guessesGreyed = true;
@@ -180,6 +190,8 @@ function startGame() {
   attemptCount = 0;
   strikes = 0;
   shapesCompleted = 0;
+  totalAttempts = 0;
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startTriangle();
 }


### PR DESCRIPTION
## Summary
- score line, triangle, quadrilateral, and complex shape drills using shapes completed versus average attempts
- add time-weighted accuracy scoring for angle memorization drills
- track and display drill highscores via data-score-key attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b075b33c8c8325bb9566b1337b574f