### PR TITLE
Hide score text and animate leaderboard

### DIFF
--- a/leaderboard.js
+++ b/leaderboard.js
@@ -27,7 +27,7 @@
     return scores.length ? Math.max(...scores) : 0;
   }
 
-  function showLeaderboard(key) {
+  function showLeaderboard(key, playerScore) {
     const storeKey = 'leaderboard_' + key;
     const data = JSON.parse(localStorage.getItem(storeKey)) || {};
     const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
@@ -50,6 +50,21 @@
     const title = document.createElement('h2');
     title.textContent = 'Leaderboard';
     overlay.appendChild(title);
+
+    if (typeof playerScore === 'number') {
+      const scoreEl = document.createElement('p');
+      scoreEl.className = 'leaderboard-score';
+      overlay.appendChild(scoreEl);
+      const duration = 1000;
+      const start = performance.now();
+      function step(now) {
+        const progress = Math.min((now - start) / duration, 1);
+        const value = Math.floor(progress * playerScore);
+        scoreEl.textContent = `Score: ${value}`;
+        if (progress < 1) requestAnimationFrame(step);
+      }
+      requestAnimationFrame(step);
+    }
 
     const list = document.createElement('div');
     list.className = 'leaderboard-list';
@@ -85,7 +100,7 @@
 
   function handleScore(key, score) {
     updateLeaderboard(key, score);
-    showLeaderboard(key);
+    showLeaderboard(key, score);
   }
 
   window.leaderboard = { handleScore, updateLeaderboard, showLeaderboard, getHighScore };

--- a/scenario.js
+++ b/scenario.js
@@ -85,7 +85,7 @@ function onShapeRevealed() {
   result.textContent = `Current avg: ${avg.toFixed(1)} px | Overall avg: ${overall.toFixed(1)} px`;
 
   if (scenarioConfig.afterAction === 'end') {
-    if (window.leaderboard) window.leaderboard.showLeaderboard(leaderboardKey);
+    if (window.leaderboard) window.leaderboard.showLeaderboard(leaderboardKey, score);
     return;
   }
   if (scenarioConfig.afterAction === 'next') {

--- a/style.css
+++ b/style.css
@@ -133,6 +133,7 @@ canvas {
   text-align: center;
   font-weight: bold;
   min-height: 1.5em;
+  display: none;
 }
 .timer {
   text-align: center;
@@ -459,6 +460,11 @@ h2, h1 { margin: 10px 0; }
 
 .leaderboard-entry {
   padding: 2px 0;
+}
+
+.leaderboard-score {
+  font-size: 1.5em;
+  margin: 10px 0;
 }
 
 .leaderboard-buttons {


### PR DESCRIPTION
## Summary
- hide score elements so text below canvas is no longer displayed
- add animated score calculation to leaderboard overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0948563288325936b929b2036e6e4