### PR TITLE
Display score formula on leaderboard

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -1,0 +1,14 @@
+/** @jest-environment jsdom */
+
+describe('leaderboard formula display', () => {
+  test('shows score formula when provided', async () => {
+    document.body.innerHTML = '<canvas></canvas>';
+    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+    await import('../leaderboard.js');
+    window.leaderboard.showLeaderboard('test', 50, 'a + b');
+    const formula = document.querySelector('.leaderboard-formula');
+    expect(formula).not.toBeNull();
+    expect(formula.textContent).toBe('Score = a + b');
+  });
+});
+

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -27,7 +27,7 @@
     return scores.length ? Math.max(...scores) : 0;
   }
 
-  function showLeaderboard(key, playerScore) {
+  function showLeaderboard(key, playerScore, formula) {
     const storeKey = 'leaderboard_' + key;
     const data = JSON.parse(localStorage.getItem(storeKey)) || {};
     const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
@@ -50,6 +50,13 @@
     const title = document.createElement('h2');
     title.textContent = 'Leaderboard';
     overlay.appendChild(title);
+
+    if (formula) {
+      const formulaEl = document.createElement('p');
+      formulaEl.className = 'leaderboard-formula';
+      formulaEl.textContent = `Score = ${formula}`;
+      overlay.appendChild(formulaEl);
+    }
 
     if (typeof playerScore === 'number') {
       const scoreEl = document.createElement('p');
@@ -98,9 +105,9 @@
     document.body.appendChild(overlay);
   }
 
-  function handleScore(key, score) {
+  function handleScore(key, score, formula) {
     updateLeaderboard(key, score);
-    showLeaderboard(key, score);
+    showLeaderboard(key, score, formula);
   }
 
   window.leaderboard = { handleScore, updateLeaderboard, showLeaderboard, getHighScore };
@@ -110,11 +117,12 @@
     if (!resultEl) return;
     const canvas = document.querySelector('canvas[data-score-key]');
     const key = canvas ? canvas.dataset.scoreKey : 'default';
+    const formula = canvas ? canvas.dataset.scoreFormula : '';
     const observer = new MutationObserver(() => {
       const m = resultEl.textContent.match(/Score:\s*(\d+)/);
       if (m) {
         const score = parseInt(m[1], 10);
-        handleScore(key, score);
+        handleScore(key, score, formula);
         observer.disconnect();
       }
     });

--- a/scenario.js
+++ b/scenario.js
@@ -85,7 +85,13 @@ function onShapeRevealed() {
   result.textContent = `Current avg: ${avg.toFixed(1)} px | Overall avg: ${overall.toFixed(1)} px`;
 
   if (scenarioConfig.afterAction === 'end') {
-    if (window.leaderboard) window.leaderboard.showLeaderboard(leaderboardKey, score);
+    if (window.leaderboard) {
+      window.leaderboard.showLeaderboard(
+        leaderboardKey,
+        score,
+        'green * 5 + yellow * 2 - red * 3 - average error'
+      );
+    }
     return;
   }
   if (scenarioConfig.afterAction === 'next') {

--- a/style.css
+++ b/style.css
@@ -462,6 +462,11 @@ h2, h1 { margin: 10px 0; }
   padding: 2px 0;
 }
 
+.leaderboard-formula {
+  font-size: 1em;
+  margin: 5px 0;
+}
+
 .leaderboard-score {
   font-size: 1.5em;
   margin: 10px 0;


### PR DESCRIPTION
## Summary
- show how scores are calculated by accepting an optional formula and presenting it above the animated tally on the leaderboard overlay
- style formula text and use scenario scoring to pass the `green * 5 + yellow * 2 - red * 3 - average error` formula
- cover formula rendering with a new Jest test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09747f6688325ba271c8fec36f942