### PR TITLE
Add scoring and leaderboard to point memorization drills

### DIFF
--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Point Drill 0.1 sec Look</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="point_drill_01"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -3,6 +3,8 @@ import { hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
 
+let scoreKey = 'point_drill_01';
+
 let playing = false;
 let awaitingClick = false;
 let target = null;
@@ -95,7 +97,18 @@ function endGame() {
   clearTimeout(gameTimer);
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
-  result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  const accuracy = stats.totalPoints
+    ? (stats.green + stats.yellow * 0.5) / stats.totalPoints
+    : 0;
+  const score = Math.round(accuracy * 1000 + stats.totalPoints * 10);
+  const accuracyPct = (accuracy * 100).toFixed(1);
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, score);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Score: ${score} (Best: ${high}) | Accuracy: ${accuracyPct}% | Points: ${stats.totalPoints} | Avg error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Score: ${score} | Accuracy: ${accuracyPct}% | Points: ${stats.totalPoints} | Avg error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -124,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   wrapper.appendChild(startBtn);
   startBtn.style.position = 'absolute';
   startBtn.style.top = '50%';

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Point Drill 0.25 sec Look</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="point_drill_025"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -3,6 +3,8 @@ import { hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
 
+let scoreKey = 'point_drill_025';
+
 let playing = false;
 let awaitingClick = false;
 let target = null;
@@ -95,7 +97,18 @@ function endGame() {
   clearTimeout(gameTimer);
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
-  result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  const accuracy = stats.totalPoints
+    ? (stats.green + stats.yellow * 0.5) / stats.totalPoints
+    : 0;
+  const score = Math.round(accuracy * 1000 + stats.totalPoints * 10);
+  const accuracyPct = (accuracy * 100).toFixed(1);
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, score);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Score: ${score} (Best: ${high}) | Accuracy: ${accuracyPct}% | Points: ${stats.totalPoints} | Avg error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Score: ${score} | Accuracy: ${accuracyPct}% | Points: ${stats.totalPoints} | Avg error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -124,6 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   wrapper.appendChild(startBtn);
   startBtn.style.position = 'absolute';
   startBtn.style.top = '50%';

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -11,7 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Point Drill 0.5 sec Look</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="point_drill_05"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -3,6 +3,8 @@ import { hideStartButton } from './src/start-button.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
 
+let scoreKey = 'point_drill_05';
+
 let playing = false;
 let awaitingClick = false;
 let target = null;
@@ -95,7 +97,18 @@ function endGame() {
   clearTimeout(gameTimer);
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
-  result.textContent = `Average error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  const accuracy = stats.totalPoints
+    ? (stats.green + stats.yellow * 0.5) / stats.totalPoints
+    : 0;
+  const score = Math.round(accuracy * 1000 + stats.totalPoints * 10);
+  const accuracyPct = (accuracy * 100).toFixed(1);
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, score);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Score: ${score} (Best: ${high}) | Accuracy: ${accuracyPct}% | Points: ${stats.totalPoints} | Avg error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Score: ${score} | Accuracy: ${accuracyPct}% | Points: ${stats.totalPoints} | Avg error: ${avg.toFixed(1)} px | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -126,6 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  scoreKey = canvas.dataset.scoreKey || scoreKey;
   wrapper.appendChild(startBtn);
   startBtn.style.position = 'absolute';
   startBtn.style.top = '50%';


### PR DESCRIPTION
## Summary
- Add score tracking and leaderboard updates to 0.1s, 0.25s and 0.5s point memorization drills
- Annotate point drill canvases with unique `data-score-key` values for leaderboard tracking
- Weight accuracy higher than quantity when calculating final drill scores

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b095e316f083259a9178e394b726f1