### PR TITLE
Fix leaderboard missing scoring formula display

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -10,5 +10,15 @@ describe('leaderboard formula display', () => {
     expect(formula).not.toBeNull();
     expect(formula.textContent).toBe('Score = a + b');
   });
+
+  test('uses default formula for known key', async () => {
+    document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
+    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+    await import('../leaderboard.js');
+    window.leaderboard.handleScore('point_drill_05', 80);
+    const formula = document.querySelector('.leaderboard-formula');
+    expect(formula).not.toBeNull();
+    expect(formula.textContent).toBe('Score = accuracy * 1000 + points * 10');
+  });
 });
 

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,4 +1,19 @@
 (function() {
+  const DEFAULT_FORMULAS = {
+    point_drill_05: 'accuracy * 1000 + points * 10',
+    point_drill_025: 'accuracy * 1000 + points * 10',
+    point_drill_01: 'accuracy * 1000 + points * 10',
+    dexterity_point_drill: 'targets hit',
+    dexterity_thin_lines: 'targets hit',
+    dexterity_thick_lines: 'targets hit',
+    dexterity_contours: 'targets hit',
+    dexterity_thick_contours: 'targets hit',
+    line_segments: 'segments traced',
+    triangles: 'correct answers',
+    quadrilaterals: 'correct answers',
+    complex_shapes: 'correct answers'
+  };
+
   function getPlayerName() {
     let name = localStorage.getItem('playerName');
     if (!name) {
@@ -106,8 +121,12 @@
   }
 
   function handleScore(key, score, formula) {
+    const f =
+      formula ||
+      DEFAULT_FORMULAS[key] ||
+      (key.startsWith('angles_') ? 'correct answers' : '');
     updateLeaderboard(key, score);
-    showLeaderboard(key, score, formula);
+    showLeaderboard(key, score, f);
   }
 
   window.leaderboard = { handleScore, updateLeaderboard, showLeaderboard, getHighScore };
@@ -117,7 +136,9 @@
     if (!resultEl) return;
     const canvas = document.querySelector('canvas[data-score-key]');
     const key = canvas ? canvas.dataset.scoreKey : 'default';
-    const formula = canvas ? canvas.dataset.scoreFormula : '';
+    const formula = canvas && canvas.dataset.scoreFormula
+      ? canvas.dataset.scoreFormula
+      : undefined;
     const observer = new MutationObserver(() => {
       const m = resultEl.textContent.match(/Score:\s*(\d+)/);
       if (m) {


### PR DESCRIPTION
## Summary
- add default scoring formulas for known drills
- fall back to default formula when none provided to leaderboard
- test displaying default scoring formula

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b099a0bb088325885cd2c284a7ad45