### PR TITLE
Add timer to point memorization drills

### DIFF
--- a/point_drill_01.html
+++ b/point_drill_01.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Point Drill 0.1 sec Look</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="point_drill_01"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -1,7 +1,8 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
+let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerDisplay;
 
 let scoreKey = 'point_drill_01';
 
@@ -11,6 +12,7 @@ let target = null;
 let endTime = 0;
 let gameTimer = null;
 let stats = null;
+let stopTimer = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const RESULT_DISPLAY_TIME = 300;
@@ -87,6 +89,7 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
   drawTarget();
 }
@@ -95,6 +98,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   const accuracy = stats.totalPoints
@@ -137,6 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   wrapper.appendChild(startBtn);
   startBtn.style.position = 'absolute';

--- a/point_drill_025.html
+++ b/point_drill_025.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Point Drill 0.25 sec Look</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="point_drill_025"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -1,7 +1,8 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
+let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerDisplay;
 
 let scoreKey = 'point_drill_025';
 
@@ -11,6 +12,7 @@ let target = null;
 let endTime = 0;
 let gameTimer = null;
 let stats = null;
+let stopTimer = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const RESULT_DISPLAY_TIME = 300;
@@ -87,6 +89,7 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
   drawTarget();
 }
@@ -95,6 +98,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   const accuracy = stats.totalPoints
@@ -137,6 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   wrapper.appendChild(startBtn);
   startBtn.style.position = 'absolute';

--- a/point_drill_05.html
+++ b/point_drill_05.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Back</button>
     <h2>Point Drill 0.5 sec Look</h2>
     <button id="startBtn">Start</button>
+    <p class="timer" id="timer">60.00</p>
     <canvas id="gameCanvas" width="500" height="500" data-score-key="point_drill_05"></canvas>
     <p class="score" id="result"></p>
   </div>

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -1,7 +1,8 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { hideStartButton } from './src/start-button.js';
+import { startCountdown } from './src/countdown.js';
 
-let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result;
+let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerDisplay;
 
 let scoreKey = 'point_drill_05';
 
@@ -11,6 +12,7 @@ let target = null;
 let endTime = 0;
 let gameTimer = null;
 let stats = null;
+let stopTimer = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const RESULT_DISPLAY_TIME = 300;
@@ -87,6 +89,7 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   endTime = Date.now() + 60000;
+  stopTimer = startCountdown(timerDisplay, 60000);
   gameTimer = setTimeout(endGame, 60000);
   drawTarget();
 }
@@ -95,6 +98,7 @@ function endGame() {
   if (!playing) return;
   playing = false;
   clearTimeout(gameTimer);
+  if (stopTimer) stopTimer();
   clearCanvas(ctx);
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   const accuracy = stats.totalPoints
@@ -139,6 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
   feedbackCtx = feedbackCanvas.getContext('2d');
   startBtn = document.getElementById('startBtn');
   result = document.getElementById('result');
+  timerDisplay = document.getElementById('timer');
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   wrapper.appendChild(startBtn);
   startBtn.style.position = 'absolute';


### PR DESCRIPTION
## Summary
- Add 60-second countdown display to point memorization drill pages
- Start and stop countdown timers in point drill scripts when games run and end

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09a1d957483258772144f86b92510