### PR TITLE
Use light grey reveal color in point drills

### DIFF
--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -40,7 +40,7 @@ function showPoints(pos, prevTarget, grade) {
   feedbackCtx.beginPath();
   feedbackCtx.arc(pos.x, pos.y, 5, 0, Math.PI * 2);
   feedbackCtx.fill();
-  feedbackCtx.fillStyle = 'blue';
+  feedbackCtx.fillStyle = '#ccc';
   feedbackCtx.beginPath();
   feedbackCtx.arc(prevTarget.x, prevTarget.y, 5, 0, Math.PI * 2);
   feedbackCtx.fill();

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -40,7 +40,7 @@ function showPoints(pos, prevTarget, grade) {
   feedbackCtx.beginPath();
   feedbackCtx.arc(pos.x, pos.y, 5, 0, Math.PI * 2);
   feedbackCtx.fill();
-  feedbackCtx.fillStyle = 'blue';
+  feedbackCtx.fillStyle = '#ccc';
   feedbackCtx.beginPath();
   feedbackCtx.arc(prevTarget.x, prevTarget.y, 5, 0, Math.PI * 2);
   feedbackCtx.fill();

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -40,7 +40,7 @@ function showPoints(pos, prevTarget, grade) {
   feedbackCtx.beginPath();
   feedbackCtx.arc(pos.x, pos.y, 5, 0, Math.PI * 2);
   feedbackCtx.fill();
-  feedbackCtx.fillStyle = 'blue';
+  feedbackCtx.fillStyle = '#ccc';
   feedbackCtx.beginPath();
   feedbackCtx.arc(prevTarget.x, prevTarget.y, 5, 0, Math.PI * 2);
   feedbackCtx.fill();


### PR DESCRIPTION
## Summary
- Replace blue target indicator with light grey in point memorization drills.
- Keep visual feedback consistent across point drill variations.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b09a7018308325a4e44f8c8ee91099