### PR TITLE
Implement unified accuracy-speed scoring for drills

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -18,7 +18,7 @@ describe('leaderboard formula display', () => {
     window.leaderboard.handleScore('point_drill_05', 80);
     const formula = document.querySelector('.leaderboard-formula');
     expect(formula).not.toBeNull();
-    expect(formula.textContent).toBe('Score = accuracy * 1000 + points * 10');
+    expect(formula.textContent).toBe('Score = accuracy * 1000 + speed * 100');
   });
 });
 

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,9 +1,9 @@
 (function() {
   const DEFAULT_FORMULAS = {
-    point_drill_05: 'accuracy * 1000 + points * 10',
-    point_drill_025: 'accuracy * 1000 + points * 10',
-    point_drill_01: 'accuracy * 1000 + points * 10',
-    dexterity_point_drill: 'targets hit',
+    point_drill_05: 'accuracy * 1000 + speed * 100',
+    point_drill_025: 'accuracy * 1000 + speed * 100',
+    point_drill_01: 'accuracy * 1000 + speed * 100',
+    dexterity_point_drill: 'accuracy * 1000 + speed * 100',
     dexterity_thin_lines: 'targets hit',
     dexterity_thick_lines: 'targets hit',
     dexterity_contours: 'targets hit',

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,0 +1,12 @@
+export function calculateScore(stats, durationMs) {
+  const green = stats.green || 0;
+  const yellow = stats.yellow || 0;
+  const red = stats.red || 0;
+  const total = green + yellow + red;
+  const accuracy = total ? (green + yellow * 0.5) / total : 0;
+  const accuracyPct = accuracy * 100;
+  const seconds = durationMs > 0 ? durationMs / 1000 : 0;
+  const speed = seconds > 0 ? green / seconds : 0;
+  const score = Math.round(accuracy * 1000 + speed * 100);
+  return { score, accuracyPct, speed };
+}


### PR DESCRIPTION
## Summary
- add reusable scoring utility computing accuracy and speed weighted toward accuracy
- refactor point drills and dexterity point drill to use new scoring and display speed
- update leaderboard default formulas and tests for new score calculation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09d2d6a6883258d8ec47c986d5b3f