### PR TITLE
Implement unified accuracy-speed scoring for drills

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -1,24 +1,31 @@
 /** @jest-environment jsdom */
 
-describe('leaderboard formula display', () => {
-  test('shows score formula when provided', async () => {
-    document.body.innerHTML = '<canvas></canvas>';
-    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
-    await import('../leaderboard.js');
-    window.leaderboard.showLeaderboard('test', 50, 'a + b');
-    const formula = document.querySelector('.leaderboard-formula');
-    expect(formula).not.toBeNull();
-    expect(formula.textContent).toBe('Score = a + b');
-  });
+  describe('leaderboard display', () => {
+    test('shows score, stats, and formula when provided', async () => {
+      document.body.innerHTML = '<canvas></canvas>';
+      window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+      await import('../leaderboard.js');
+      window.leaderboard.showLeaderboard('test', 50, 'a + b', 75.5, 1.23);
+      const stats = document.querySelector('.leaderboard-stats');
+      expect(stats).not.toBeNull();
+      expect(stats.textContent).toBe('Accuracy: 75.5% | Speed: 1.23/s');
+      const formula = document.querySelector('.leaderboard-formula');
+      expect(formula).not.toBeNull();
+      expect(formula.textContent).toBe('Score = a + b');
+    });
 
-  test('uses default formula for known key', async () => {
-    document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
-    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
-    await import('../leaderboard.js');
-    window.leaderboard.handleScore('point_drill_05', 80);
-    const formula = document.querySelector('.leaderboard-formula');
-    expect(formula).not.toBeNull();
-    expect(formula.textContent).toBe('Score = accuracy * 1000 + points * 10');
+    test('uses default formula for known key and shows stats', async () => {
+      document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
+      window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+      await import('../leaderboard.js');
+      localStorage.setItem('playerName', 'Tester');
+      window.leaderboard.handleScore('point_drill_05', 80, undefined, 80, 2);
+      const stats = document.querySelector('.leaderboard-stats');
+      expect(stats).not.toBeNull();
+      expect(stats.textContent).toBe('Accuracy: 80.0% | Speed: 2.00/s');
+      const formula = document.querySelector('.leaderboard-formula');
+      expect(formula).not.toBeNull();
+      expect(formula.textContent).toBe('Score = accuracy * 1000 + speed * 100');
+    });
   });
-});
 

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,9 +1,9 @@
 (function() {
   const DEFAULT_FORMULAS = {
-    point_drill_05: 'accuracy * 1000 + points * 10',
-    point_drill_025: 'accuracy * 1000 + points * 10',
-    point_drill_01: 'accuracy * 1000 + points * 10',
-    dexterity_point_drill: 'targets hit',
+    point_drill_05: 'accuracy * 1000 + speed * 100',
+    point_drill_025: 'accuracy * 1000 + speed * 100',
+    point_drill_01: 'accuracy * 1000 + speed * 100',
+    dexterity_point_drill: 'accuracy * 1000 + speed * 100',
     dexterity_thin_lines: 'targets hit',
     dexterity_thick_lines: 'targets hit',
     dexterity_contours: 'targets hit',
@@ -42,7 +42,7 @@
     return scores.length ? Math.max(...scores) : 0;
   }
 
-  function showLeaderboard(key, playerScore, formula) {
+  function showLeaderboard(key, playerScore, formula, accuracy, speed) {
     const storeKey = 'leaderboard_' + key;
     const data = JSON.parse(localStorage.getItem(storeKey)) || {};
     const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
@@ -66,13 +66,6 @@
     title.textContent = 'Leaderboard';
     overlay.appendChild(title);
 
-    if (formula) {
-      const formulaEl = document.createElement('p');
-      formulaEl.className = 'leaderboard-formula';
-      formulaEl.textContent = `Score = ${formula}`;
-      overlay.appendChild(formulaEl);
-    }
-
     if (typeof playerScore === 'number') {
       const scoreEl = document.createElement('p');
       scoreEl.className = 'leaderboard-score';
@@ -86,6 +79,23 @@
         if (progress < 1) requestAnimationFrame(step);
       }
       requestAnimationFrame(step);
+    }
+
+    if (typeof accuracy === 'number' || typeof speed === 'number') {
+      const statsEl = document.createElement('p');
+      statsEl.className = 'leaderboard-stats';
+      const parts = [];
+      if (typeof accuracy === 'number') parts.push(`Accuracy: ${accuracy.toFixed(1)}%`);
+      if (typeof speed === 'number') parts.push(`Speed: ${speed.toFixed(2)}/s`);
+      statsEl.textContent = parts.join(' | ');
+      overlay.appendChild(statsEl);
+    }
+
+    if (formula) {
+      const formulaEl = document.createElement('p');
+      formulaEl.className = 'leaderboard-formula';
+      formulaEl.textContent = `Score = ${formula}`;
+      overlay.appendChild(formulaEl);
     }
 
     const list = document.createElement('div');
@@ -120,13 +130,13 @@
     document.body.appendChild(overlay);
   }
 
-  function handleScore(key, score, formula) {
+  function handleScore(key, score, formula, accuracy, speed) {
     const f =
       formula ||
       DEFAULT_FORMULAS[key] ||
       (key.startsWith('angles_') ? 'correct answers' : '');
     updateLeaderboard(key, score);
-    showLeaderboard(key, score, f);
+    showLeaderboard(key, score, f, accuracy, speed);
   }
 
   window.leaderboard = { handleScore, updateLeaderboard, showLeaderboard, getHighScore };
@@ -143,7 +153,11 @@
       const m = resultEl.textContent.match(/Score:\s*(\d+)/);
       if (m) {
         const score = parseInt(m[1], 10);
-        handleScore(key, score, formula);
+        const accMatch = resultEl.textContent.match(/Accuracy:\s*(\d+(?:\.\d+)?)%/);
+        const spdMatch = resultEl.textContent.match(/Speed:\s*(\d+(?:\.\d+)?)/);
+        const accuracy = accMatch ? parseFloat(accMatch[1]) : undefined;
+        const speed = spdMatch ? parseFloat(spdMatch[1]) : undefined;
+        handleScore(key, score, formula, accuracy, speed);
         observer.disconnect();
       }
     });

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,0 +1,12 @@
+export function calculateScore(stats, durationMs) {
+  const green = stats.green || 0;
+  const yellow = stats.yellow || 0;
+  const red = stats.red || 0;
+  const total = green + yellow + red;
+  const accuracy = total ? (green + yellow * 0.5) / total : 0;
+  const accuracyPct = accuracy * 100;
+  const seconds = durationMs > 0 ? durationMs / 1000 : 0;
+  const speed = seconds > 0 ? green / seconds : 0;
+  const score = Math.round(accuracy * 1000 + speed * 100);
+  return { score, accuracyPct, speed };
+}


### PR DESCRIPTION
## Summary
- show accuracy and speed between score and formula on leaderboard overlay
- parse accuracy and speed from result text when triggering leaderboard
- test leaderboard displays stats and default formula

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b09d2d6a6883258d8ec47c986d5b3f