### PR TITLE
feat: unify scoring across drills

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -36,4 +36,4 @@
     expect(formula).not.toBeNull();
     expect(formula.textContent).toBe('Score = accuracy * 1000 + speed * 100');
   });
-
+});

--- a/complex_shapes.js
+++ b/complex_shapes.js
@@ -19,6 +19,8 @@ let strikes = 0;
 let shapesCompleted = 0;
 let totalAttempts = 0;
 let scoreKey = 'complex_shapes';
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
 const NEW_SHAPE_DELAY = 3000;
@@ -234,14 +236,15 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
-  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
-  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
-  if (score > high) {
-    high = score;
-    localStorage.setItem(scoreKey, high.toString());
+  const elapsed = Date.now() - startTime;
+  const { score: finalScore, accuracyPct, speed } = calculateScore(stats, elapsed);
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, finalScore);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Struck out! Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Struck out! Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
   }
-  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function startShape() {
@@ -265,6 +268,8 @@ function startGame() {
   strikes = 0;
   shapesCompleted = 0;
   totalAttempts = 0;
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startShape();
@@ -310,6 +315,9 @@ function pointerUp() {
   const grade = accuracy >= 0.9 ? 'green' : accuracy >= 0.8 ? 'yellow' : 'red';
   const hadRed = segmentGrades.includes('red');
   playSound(audioCtx, grade);
+  if (grade === 'green') stats.green++;
+  else if (grade === 'yellow') stats.yellow++;
+  else stats.red++;
   attemptCount++;
 
   if (hadRed) {

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -1,14 +1,16 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
+import { calculateScore } from './src/scoring.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
-let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_contours';
 let stopTimer = null;
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
 
 let drawing = false;
 let activeTarget = null;
@@ -104,7 +106,8 @@ function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
-  score = 0;
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
   targets = [randomCurve(), randomCurve()];
@@ -119,12 +122,18 @@ function endGame() {
   clearTimeout(gameTimer);
   if (stopTimer) stopTimer();
   clearCanvas(ctx);
-  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
-  if (score > high) {
-    high = score;
-    localStorage.setItem(scoreKey, high.toString());
+  const elapsed = Date.now() - startTime;
+  const { score: finalScore, accuracyPct, speed } = calculateScore(
+    { green: stats.green, yellow: 0, red: stats.red },
+    elapsed
+  );
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, finalScore);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
-  result.textContent = `Score: ${score} (Best: ${high})`;
 }
 
 function projectPointToCurve(p, curve) {
@@ -235,11 +244,12 @@ function pointerUp(e) {
   const offRatio = totalSegments > 0 ? offLineSegments / totalSegments : 1;
   const coverage = maxT - minT;
   if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
-    score++;
+    stats.green++;
     playSound(audioCtx, 'green');
     targets[activeTarget] = randomCurve();
     drawTargets();
   } else {
+    stats.red++;
     playSound(audioCtx, 'red');
   }
   activeTarget = null;

--- a/dexterity_thick_contours.js
+++ b/dexterity_thick_contours.js
@@ -1,14 +1,16 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
+import { calculateScore } from './src/scoring.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
-let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_thick_contours';
 let stopTimer = null;
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
 
 let drawing = false;
 let activeTarget = null;
@@ -104,7 +106,8 @@ function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
-  score = 0;
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
   targets = [randomCurve(), randomCurve()];
@@ -119,12 +122,18 @@ function endGame() {
   clearTimeout(gameTimer);
   if (stopTimer) stopTimer();
   clearCanvas(ctx);
-  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
-  if (score > high) {
-    high = score;
-    localStorage.setItem(scoreKey, high.toString());
+  const elapsed = Date.now() - startTime;
+  const { score: finalScore, accuracyPct, speed } = calculateScore(
+    { green: stats.green, yellow: 0, red: stats.red },
+    elapsed
+  );
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, finalScore);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
-  result.textContent = `Score: ${score} (Best: ${high})`;
 }
 
 function projectPointToCurve(p, curve) {
@@ -235,11 +244,12 @@ function pointerUp(e) {
   const offRatio = totalSegments > 0 ? offLineSegments / totalSegments : 1;
   const coverage = maxT - minT;
   if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
-    score++;
+    stats.green++;
     playSound(audioCtx, 'green');
     targets[activeTarget] = randomCurve();
     drawTargets();
   } else {
+    stats.red++;
     playSound(audioCtx, 'red');
   }
   activeTarget = null;

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -1,14 +1,16 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
+import { calculateScore } from './src/scoring.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
-let score = 0;
 let gameTimer = null;
 let scoreKey = 'dexterity_thick_lines';
 let stopTimer = null;
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
 
 let drawing = false;
 let activeTarget = null;
@@ -69,7 +71,8 @@ function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
   playing = true;
-  score = 0;
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
   targets = [randomLine(), randomLine()];
@@ -84,12 +87,18 @@ function endGame() {
   clearTimeout(gameTimer);
   if (stopTimer) stopTimer();
   clearCanvas(ctx);
-  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
-  if (score > high) {
-    high = score;
-    localStorage.setItem(scoreKey, high.toString());
+  const elapsed = Date.now() - startTime;
+  const { score: finalScore, accuracyPct, speed } = calculateScore(
+    { green: stats.green, yellow: 0, red: stats.red },
+    elapsed
+  );
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, finalScore);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
-  result.textContent = `Score: ${score} (Best: ${high})`;
 }
 
 function projectPointToSegment(p, seg) {
@@ -179,11 +188,12 @@ function pointerUp(e) {
   const offRatio = totalSegments > 0 ? offLineSegments / totalSegments : 1;
   const coverage = maxT - minT;
   if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
-    score++;
+    stats.green++;
     playSound(audioCtx, 'green');
     targets[activeTarget] = randomLine();
     drawTargets();
   } else {
+    stats.red++;
     playSound(audioCtx, 'red');
   }
   activeTarget = null;

--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -1,6 +1,7 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { generateShape } from './geometry.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { calculateScore } from './src/scoring.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -15,6 +16,8 @@ let shapesCompleted = 0;
 let totalAttempts = 0;
 let scoreKey = 'quadrilaterals';
 let attemptHasRed = false;
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
 const NEW_QUADRILATERAL_DELAY = 3000;
@@ -77,14 +80,15 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
-  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
-  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
-  if (score > high) {
-    high = score;
-    localStorage.setItem(scoreKey, high.toString());
+  const elapsed = Date.now() - startTime;
+  const { score: finalScore, accuracyPct, speed } = calculateScore(stats, elapsed);
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, finalScore);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Struck out! Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Struck out! Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
   }
-  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function finishCycle() {
@@ -136,6 +140,9 @@ function pointerDown(e) {
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
     if (grade === 'red') attemptHasRed = true;
+    if (grade === 'green') stats.green++;
+    else if (grade === 'yellow') stats.yellow++;
+    else stats.red++;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
@@ -146,6 +153,9 @@ function pointerDown(e) {
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
     if (grade === 'red') attemptHasRed = true;
+    if (grade === 'green') stats.green++;
+    else if (grade === 'yellow') stats.yellow++;
+    else stats.red++;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
@@ -175,6 +185,8 @@ function startGame() {
   strikes = 0;
   shapesCompleted = 0;
   totalAttempts = 0;
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startQuadrilateral();

--- a/triangles.js
+++ b/triangles.js
@@ -1,5 +1,6 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
+import { calculateScore } from './src/scoring.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -14,6 +15,8 @@ let shapesCompleted = 0;
 let totalAttempts = 0;
 let scoreKey = 'triangles';
 let attemptHasRed = false;
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
 const NEW_TRIANGLE_DELAY = 3000;
@@ -93,14 +96,15 @@ function updateStrikes() {
 
 function endGame() {
   playing = false;
-  const avg = shapesCompleted ? totalAttempts / shapesCompleted : 0;
-  const score = shapesCompleted ? Math.round((shapesCompleted * 100) / avg) : 0;
-  let high = parseInt(localStorage.getItem(scoreKey)) || 0;
-  if (score > high) {
-    high = score;
-    localStorage.setItem(scoreKey, high.toString());
+  const elapsed = Date.now() - startTime;
+  const { score: finalScore, accuracyPct, speed } = calculateScore(stats, elapsed);
+  if (window.leaderboard) {
+    window.leaderboard.updateLeaderboard(scoreKey, finalScore);
+    const high = window.leaderboard.getHighScore(scoreKey);
+    result.textContent = `Struck out! Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
+  } else {
+    result.textContent = `Struck out! Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Yellow: ${stats.yellow} Red: ${stats.red}`;
   }
-  result.textContent = `Struck out! Score: ${score} (Best: ${high})`;
 }
 
 function finishCycle() {
@@ -152,6 +156,9 @@ function pointerDown(e) {
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
     if (grade === 'red') attemptHasRed = true;
+    if (grade === 'green') stats.green++;
+    else if (grade === 'yellow') stats.yellow++;
+    else stats.red++;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
@@ -162,6 +169,9 @@ function pointerDown(e) {
     const grade = gradeDistance(dist);
     guesses.push({ x: pos.x, y: pos.y, grade });
     if (grade === 'red') attemptHasRed = true;
+    if (grade === 'green') stats.green++;
+    else if (grade === 'yellow') stats.yellow++;
+    else stats.red++;
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
@@ -191,6 +201,8 @@ function startGame() {
   strikes = 0;
   shapesCompleted = 0;
   totalAttempts = 0;
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
   startTriangle();


### PR DESCRIPTION
## Summary
- apply shared accuracy/speed scoring to line dexterity drills
- adopt unified scoring for shape memorization drills and scenarios
- ensure leaderboard tests cover default formula behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a2baff0483258c1bfd1e6740e58a