### PR TITLE
Remove formula from leaderboard and clarify speed stat

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -1,39 +1,28 @@
 /** @jest-environment jsdom */
 
-  describe('leaderboard display', () => {
-    test('shows score, stats, and formula when provided', async () => {
-      document.body.innerHTML = '<canvas></canvas>';
-      window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
-      await import('../leaderboard.js');
-      window.leaderboard.showLeaderboard('test', 50, 'a + b', 75.5, 1.23);
-      const stats = document.querySelector('.leaderboard-stats');
-      expect(stats).not.toBeNull();
-      expect(stats.textContent).toBe('Accuracy: 75.5% | Speed: 1.23/s');
-      const formula = document.querySelector('.leaderboard-formula');
-      expect(formula).not.toBeNull();
-      expect(formula.textContent).toBe('Score = a + b');
-    });
+describe('leaderboard display', () => {
+  test('shows score and stats when provided', async () => {
+    document.body.innerHTML = '<canvas></canvas>';
+    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+    await import('../leaderboard.js');
+    window.leaderboard.showLeaderboard('test', 50, 75.5, 1.23);
+    const stats = document.querySelector('.leaderboard-stats');
+    expect(stats).not.toBeNull();
+    expect(stats.textContent).toBe('Accuracy: 75.5% | Avg time per target: 0.81s');
+    const formula = document.querySelector('.leaderboard-formula');
+    expect(formula).toBeNull();
+  });
 
-    test('uses default formula for known key and shows stats', async () => {
-      document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
-      window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
-      await import('../leaderboard.js');
-      localStorage.setItem('playerName', 'Tester');
-      window.leaderboard.handleScore('point_drill_05', 80, undefined, 80, 2);
-      const stats = document.querySelector('.leaderboard-stats');
-      expect(stats).not.toBeNull();
-      expect(stats.textContent).toBe('Accuracy: 80.0% | Speed: 2.00/s');
-      const formula = document.querySelector('.leaderboard-formula');
-      expect(formula).not.toBeNull();
-      expect(formula.textContent).toBe('Score = accuracy * 1000 + speed * 100');
-    });
-  test('uses default formula for known key', async () => {
+  test('handleScore displays stats without formula', async () => {
     document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
     window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
     await import('../leaderboard.js');
-    window.leaderboard.handleScore('point_drill_05', 80);
+    localStorage.setItem('playerName', 'Tester');
+    window.leaderboard.handleScore('point_drill_05', 80, 80, 2);
+    const stats = document.querySelector('.leaderboard-stats');
+    expect(stats).not.toBeNull();
+    expect(stats.textContent).toBe('Accuracy: 80.0% | Avg time per target: 0.50s');
     const formula = document.querySelector('.leaderboard-formula');
-    expect(formula).not.toBeNull();
-    expect(formula.textContent).toBe('Score = accuracy * 1000 + speed * 100');
+    expect(formula).toBeNull();
   });
 });

--- a/scenario.js
+++ b/scenario.js
@@ -96,8 +96,7 @@ function onShapeRevealed() {
     if (window.leaderboard) {
       window.leaderboard.showLeaderboard(
         leaderboardKey,
-        finalScore,
-        'accuracy * 1000 + speed * 100'
+        finalScore
       );
     }
     return;

--- a/style.css
+++ b/style.css
@@ -462,11 +462,6 @@ h2, h1 { margin: 10px 0; }
   padding: 2px 0;
 }
 
-.leaderboard-formula {
-  font-size: 1em;
-  margin: 5px 0;
-}
-
 .leaderboard-score {
   font-size: 1.5em;
   margin: 10px 0;


### PR DESCRIPTION
## Summary
- drop scoring formula from leaderboard overlay
- show speed as average time per target for clearer interpretation
- adjust tests and scenario call for simplified leaderboard API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0af8fe7b08325aa1aef7a9d118956