### PR TITLE
Manual drill progression for scenario player and custom leaderboard actions

### DIFF
--- a/leaderboard.js
+++ b/leaderboard.js
@@ -95,18 +95,36 @@
     const buttons = document.createElement('div');
     buttons.className = 'leaderboard-buttons';
 
-    const retry = document.createElement('button');
-    retry.textContent = 'Retry';
-    retry.addEventListener('click', () => location.reload());
+    if (window.parent && window.parent.scenarioNext) {
+      const back = document.createElement('button');
+      back.textContent = 'Back to scenarios';
+      back.addEventListener('click', () => {
+        window.parent.location.href = 'scenarios.html';
+      });
 
-    const back = document.createElement('button');
-    back.textContent = 'Back to drills';
-    back.addEventListener('click', () => {
-      window.location.href = 'drills.html';
-    });
+      const next = document.createElement('button');
+      next.textContent = 'Next drill';
+      next.addEventListener('click', () => {
+        window.parent.scenarioNext();
+      });
 
-    buttons.appendChild(retry);
-    buttons.appendChild(back);
+      buttons.appendChild(back);
+      buttons.appendChild(next);
+    } else {
+      const retry = document.createElement('button');
+      retry.textContent = 'Retry';
+      retry.addEventListener('click', () => location.reload());
+
+      const back = document.createElement('button');
+      back.textContent = 'Back to drills';
+      back.addEventListener('click', () => {
+        window.location.href = 'drills.html';
+      });
+
+      buttons.appendChild(retry);
+      buttons.appendChild(back);
+    }
+
     overlay.appendChild(buttons);
 
     document.body.appendChild(overlay);

--- a/scenario_player.js
+++ b/scenario_player.js
@@ -14,7 +14,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const frame = document.getElementById('drillFrame');
 
   let observer;
-  const NEXT_DELAY = 1500; // delay to show score before next drill
 
   const resizeFrame = () => {
     try {
@@ -50,22 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
       // Hide inner back button to avoid duplicate navigation controls
       const innerBack = doc.getElementById('backBtn');
       if (innerBack) innerBack.style.display = 'none';
-
-      // Observe result element to auto-advance after score is shown
-      const resultEl = doc.getElementById('result');
-      if (resultEl) {
-        let advanced = false;
-        const resultObserver = new MutationObserver(() => {
-          if (!advanced && resultEl.textContent.trim() !== '') {
-            advanced = true;
-            setTimeout(() => {
-              index++;
-              loadCurrent();
-            }, NEXT_DELAY);
-          }
-        });
-        resultObserver.observe(resultEl, { childList: true, subtree: true });
-      }
     } catch {
       // Ignore cross-origin access errors
     }
@@ -94,6 +77,11 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = 'scenarios.html';
     }
   }
+
+  window.scenarioNext = () => {
+    index++;
+    loadCurrent();
+  };
 
   loadCurrent();
 });


### PR DESCRIPTION
## Summary
- Remove automatic next-drill transition in scenario player and expose a global `scenarioNext` function for manual control
- Customize leaderboard overlay to show **Back to scenarios** and **Next drill** buttons when used within scenario player

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c8a533ec83259bdfda127ff9f9d7