### PR TITLE
Reduce buffer after shape completion

### DIFF
--- a/complex_shapes.js
+++ b/complex_shapes.js
@@ -23,7 +23,7 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_SHAPE_DELAY = 3000;
+const NEW_SHAPE_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function gradeDistance(d) {

--- a/line_segments.js
+++ b/line_segments.js
@@ -19,7 +19,7 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_SEGMENT_DELAY = 3000;
+const NEW_SEGMENT_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateSegment() {

--- a/quadrilaterals.js
+++ b/quadrilaterals.js
@@ -20,7 +20,7 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_QUADRILATERAL_DELAY = 3000;
+const NEW_QUADRILATERAL_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateQuadrilateral() {

--- a/triangles.js
+++ b/triangles.js
@@ -19,7 +19,7 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_TRIANGLE_DELAY = 3000;
+const NEW_TRIANGLE_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateTriangle() {


### PR DESCRIPTION
## Summary
- Accelerated flow of shape memorization drills by cutting the post-completion buffer to 1s

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3055f2d408325868ea5367305ec5f