### PR TITLE
Improve shape generation and ghost point visibility

### DIFF
--- a/__tests__/geometry.test.js
+++ b/__tests__/geometry.test.js
@@ -25,6 +25,17 @@ describe('generateShape', () => {
     expect(boxHeight).toBeGreaterThanOrEqual(60);
   });
 
+  test('generates shapes with sufficient area', () => {
+    const points = generateShape(4, width, height, 'medium');
+    let area = 0;
+    for (let i = 0; i < points.length; i++) {
+      const j = (i + 1) % points.length;
+      area += points[i].x * points[j].y - points[j].x * points[i].y;
+    }
+    area = Math.abs(area) / 2;
+    expect(area).toBeGreaterThanOrEqual(7200);
+  });
+
   test('handles single point generation', () => {
     const points = generateShape(1, width, height);
     expect(points).toHaveLength(1);

--- a/app.js
+++ b/app.js
@@ -128,9 +128,9 @@ function retryShape() {
   drawShape(originalShape, "black");
   if (ghostShape.length) {
     if (drawModeToggle?.checked) {
-      ghostShape.forEach(pt => drawDot(pt, "#ccc"));
+      ghostShape.forEach(pt => drawDot(pt, "#ccc", false));
     } else if (ghostShape.length === 1) {
-      drawDot(ghostShape[0], "#ccc");
+      drawDot(ghostShape[0], "#ccc", false);
     } else if (ghostShape.length > 1) {
       ctx.beginPath();
       ctx.moveTo(ghostShape[0].x, ghostShape[0].y);
@@ -183,8 +183,17 @@ export function drawGivenPoints(points) {
   if (document.getElementById("giveRightmost").checked) drawDot(extremes.right, "blue");
 }
 
-function drawDot(pt, color) {
-  ctx.beginPath(); ctx.arc(pt.x, pt.y, 5, 0, 2 * Math.PI); ctx.fillStyle = color; ctx.fill();
+function drawDot(pt, color, fill = true) {
+  ctx.beginPath();
+  ctx.arc(pt.x, pt.y, 5, 0, 2 * Math.PI);
+  if (fill) {
+    ctx.fillStyle = color;
+    ctx.fill();
+  } else {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
 }
 
 function gradePoint(p) {

--- a/geometry.js
+++ b/geometry.js
@@ -13,6 +13,7 @@ export function generateShape(sides, width, height, size = 'medium') {
   };
   const radius = sizeMap[size] || 120;
   const minDim = 60;
+  const minArea = (radius * radius) / 2;
 
   const cx = width / 2;
   const cy = height / 2;
@@ -20,6 +21,7 @@ export function generateShape(sides, width, height, size = 'medium') {
   let points = [];
   let boxWidth = 0;
   let boxHeight = 0;
+  let area = 0;
 
   do {
     const angleOffset = Math.random() * Math.PI * 2;
@@ -36,9 +38,19 @@ export function generateShape(sides, width, height, size = 'medium') {
     const ys = points.map(p => p.y);
     boxWidth = Math.max(...xs) - Math.min(...xs);
     boxHeight = Math.max(...ys) - Math.min(...ys);
-  } while (boxWidth < minDim || boxHeight < minDim);
+    area = polygonArea(points);
+  } while (boxWidth < minDim || boxHeight < minDim || area < minArea);
 
   return points;
+}
+
+function polygonArea(points) {
+  let sum = 0;
+  for (let i = 0; i < points.length; i++) {
+    const j = (i + 1) % points.length;
+    sum += points[i].x * points[j].y - points[j].x * points[i].y;
+  }
+  return Math.abs(sum) / 2;
 }
 
 export function distancePointToSegment(p, a, b) {


### PR DESCRIPTION
## Summary
- Ensure generated shapes have a minimum area to avoid nearly invisible skinny shapes
- Draw ghost points as hollow circles so vertices remain unobstructed
- Test that generated shapes meet the area requirement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30b63c13483258fc1135f400b8009