### PR TITLE
Add buffer between grading and sequence phases

### DIFF
--- a/point_sequence.js
+++ b/point_sequence.js
@@ -17,6 +17,7 @@ let startTime = 0;
 const BETWEEN_DELAY = 250;
 const FEEDBACK_TIME = 1500;
 const FLASH_INTERVAL = 500;
+const AFTER_GRADE_DELAY = 500;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generatePoint() {
@@ -74,7 +75,9 @@ function flashGuesses(callback) {
     clearInterval(interval);
     clearCanvas(feedbackCtx);
     clearCanvas(ctx);
-    if (callback) callback();
+    if (callback) {
+      setTimeout(callback, AFTER_GRADE_DELAY);
+    }
   }, FEEDBACK_TIME);
 }
 


### PR DESCRIPTION
## Summary
- add delay after grading to visually separate phases in sequence drills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3212e196c8325b3969ed8a155f31f