### PR TITLE
Ensure grading phase occurs after orange point in point sequence drill

### DIFF
--- a/point_sequence.js
+++ b/point_sequence.js
@@ -122,18 +122,14 @@ function pointerDown(e) {
   if (grade !== 'green') {
     drawFeedbackPoint(feedbackCtx, pos, color);
     state = 'feedback';
-    if (grade === 'yellow') {
-      setTimeout(() => {
-        if (playing) startRound(false);
-      }, AFTER_GRADE_DELAY);
-      return;
-    }
     flashGuesses(() => {
-      strikes++;
-      updateStrikes();
-      if (strikes >= 3) {
-        endGame();
-        return;
+      if (grade === 'red') {
+        strikes++;
+        updateStrikes();
+        if (strikes >= 3) {
+          endGame();
+          return;
+        }
       }
       if (playing) startRound(false);
     });


### PR DESCRIPTION
## Summary
- keep grading animation after orange-point guesses in point sequence drill

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3294f3b248325ab63abeed6171e82