### PR TITLE
Display points in memorization drills

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -12,40 +12,40 @@
     <h2>Drills</h2>
     <input id="searchInput" type="text" placeholder="Search drills..." />
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="line_segments.html" data-difficulty="Beginner" data-score-key="line_segments">
+      <div class="exercise-item" data-link="two_points.html" data-difficulty="Beginner" data-score-key="two_points">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
-          <span class="subject-label">Lines</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Line Segments</h3>
-          <p>Memorize line segment endpoints.</p>
+          <h3>Two Points</h3>
+          <p>Memorize two points.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner" data-score-key="triangles">
+      <div class="exercise-item" data-link="three_points.html" data-difficulty="Beginner" data-score-key="three_points">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
-          <span class="subject-label">Shapes</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Triangles</h3>
-          <p>Memorize triangle vertices.</p>
+          <h3>Three Points</h3>
+          <p>Memorize three points.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept" data-score-key="quadrilaterals">
+      <div class="exercise-item" data-link="four_points.html" data-difficulty="Adept" data-score-key="four_points">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
-          <span class="subject-label">Shapes</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Quadrilaterals</h3>
-          <p>Memorize quadrilateral vertices.</p>
+          <h3>Four Points</h3>
+          <p>Memorize four points.</p>
         </div>
       </div>
       <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert" data-score-key="complex_shapes">

--- a/drills_data.js
+++ b/drills_data.js
@@ -1,7 +1,7 @@
 export const drills = [
-  { name: 'Line Segments', url: 'line_segments.html', description: 'Memorize line segment endpoints.', category: 'Memorization', subject: 'Lines', difficulty: 'Beginner' },
-  { name: 'Triangles', url: 'triangles.html', description: 'Memorize triangle vertices.', category: 'Memorization', subject: 'Shapes', difficulty: 'Beginner' },
-  { name: 'Quadrilaterals', url: 'quadrilaterals.html', description: 'Memorize quadrilateral vertices.', category: 'Memorization', subject: 'Shapes', difficulty: 'Adept' },
+  { name: 'Two Points', url: 'two_points.html', description: 'Memorize two points.', category: 'Memorization', subject: 'Points', difficulty: 'Beginner' },
+  { name: 'Three Points', url: 'three_points.html', description: 'Memorize three points.', category: 'Memorization', subject: 'Points', difficulty: 'Beginner' },
+  { name: 'Four Points', url: 'four_points.html', description: 'Memorize four points.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
   { name: 'Complex Shapes', url: 'complex_shapes.html', description: 'Memorize mixed curved and straight shapes.', category: 'Memorization', subject: 'Shapes', difficulty: 'Expert' },
   { name: 'Angles (5° increments)', url: 'angles.html', description: 'Guess randomly oriented angles in 5° steps.', category: 'Memorization', subject: 'Angles', difficulty: 'Expert' },
   { name: 'Angles (10° increments)', url: 'angles.html?step=10', description: 'Guess randomly oriented angles in 10° steps.', category: 'Memorization', subject: 'Angles', difficulty: 'Beginner' },

--- a/four_points.html
+++ b/four_points.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Line Segments - Memory Shape Drawing Game</title>
+  <title>Four Points - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="practice-screen">
     <button id="backBtn">← Back</button>
-    <h2>Line Segments</h2>
+    <h2>Four Points</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500" data-score-key="line_segments"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="four_points"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>
@@ -20,7 +20,7 @@
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>
-  <script type="module" src="line_segments.js"></script>
+  <script type="module" src="four_points.js"></script>
   <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/four_points.js
+++ b/four_points.js
@@ -14,7 +14,7 @@ let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
 let totalAttempts = 0;
-let scoreKey = 'quadrilaterals';
+let scoreKey = 'four_points';
 let attemptHasRed = false;
 let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
@@ -41,13 +41,11 @@ function drawQuadrilateral(show = true) {
   clearCanvas(ctx);
   if (show) {
     ctx.fillStyle = 'black';
-    ctx.beginPath();
-    ctx.moveTo(vertices[0].x, vertices[0].y);
-    for (let i = 1; i < vertices.length; i++) {
-      ctx.lineTo(vertices[i].x, vertices[i].y);
-    }
-    ctx.closePath();
-    ctx.fill();
+    vertices.forEach(v => {
+      ctx.beginPath();
+      ctx.arc(v.x, v.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+    });
   }
   drawGuesses();
 }

--- a/memorization.html
+++ b/memorization.html
@@ -11,38 +11,38 @@
     <button id="backBtn">← Back</button>
     <h2>Memorization</h2>
     <div id="exerciseList" class="exercise-list">
-      <div class="exercise-item" data-link="line_segments.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="two_points.html" data-difficulty="Beginner">
         <div class="tag-container">
           <span class="category-label category-memorization">Memorization</span>
-          <span class="subject-label">Lines</span>
+          <span class="subject-label">Points</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Line Segments</h3>
-          <p>Memorize line segment endpoints.</p>
+          <h3>Two Points</h3>
+          <p>Memorize two points.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="triangles.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="three_points.html" data-difficulty="Beginner">
         <div class="tag-container">
           <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-beginner">Beginner</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Triangles</h3>
-          <p>Memorize triangle vertices.</p>
+          <h3>Three Points</h3>
+          <p>Memorize three points.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="quadrilaterals.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="four_points.html" data-difficulty="Adept">
         <div class="tag-container">
           <span class="category-label category-memorization">Memorization</span>
           <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Quadrilaterals</h3>
-          <p>Memorize quadrilateral vertices.</p>
+          <h3>Four Points</h3>
+          <p>Memorize four points.</p>
         </div>
       </div>
       <div class="exercise-item" data-link="complex_shapes.html" data-difficulty="Expert">

--- a/scenarios.js
+++ b/scenarios.js
@@ -53,17 +53,17 @@ export const scenarioData = {
     difficulty: 'Adept',
     subject: 'Points'
   },
-  "Triangles": {
-    url: 'triangles.html',
-    description: 'Memorize triangle vertices.',
+  "Three Points": {
+    url: 'three_points.html',
+    description: 'Memorize three points.',
     difficulty: 'Beginner',
-    subject: 'Shapes'
+    subject: 'Points'
   },
-  "Quadrilaterals": {
-    url: 'quadrilaterals.html',
-    description: 'Memorize quadrilateral vertices.',
+  "Four Points": {
+    url: 'four_points.html',
+    description: 'Memorize four points.',
     difficulty: 'Adept',
-    subject: 'Shapes'
+    subject: 'Points'
   }
 };
 

--- a/three_points.html
+++ b/three_points.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Quadrilaterals - Memory Shape Drawing Game</title>
+  <title>Three Points - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="practice-screen">
     <button id="backBtn">← Back</button>
-    <h2>Quadrilaterals</h2>
+    <h2>Three Points</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500" data-score-key="quadrilaterals"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="three_points"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>
@@ -20,7 +20,7 @@
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>
-  <script type="module" src="quadrilaterals.js"></script>
+  <script type="module" src="three_points.js"></script>
   <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/three_points.js
+++ b/three_points.js
@@ -13,7 +13,7 @@ let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
 let totalAttempts = 0;
-let scoreKey = 'triangles';
+let scoreKey = 'three_points';
 let attemptHasRed = false;
 let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
@@ -58,12 +58,11 @@ function drawTriangle(show = true) {
   clearCanvas(ctx);
   if (show) {
     ctx.fillStyle = 'black';
-    ctx.beginPath();
-    ctx.moveTo(vertices[0].x, vertices[0].y);
-    ctx.lineTo(vertices[1].x, vertices[1].y);
-    ctx.lineTo(vertices[2].x, vertices[2].y);
-    ctx.closePath();
-    ctx.fill();
+    vertices.forEach(v => {
+      ctx.beginPath();
+      ctx.arc(v.x, v.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+    });
   }
   drawGuesses();
 }

--- a/two_points.html
+++ b/two_points.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Triangles - Memory Shape Drawing Game</title>
+  <title>Two Points - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="practice-screen">
     <button id="backBtn">← Back</button>
-    <h2>Triangles</h2>
+    <h2>Two Points</h2>
     <button id="startBtn">Start</button>
-    <canvas id="gameCanvas" width="500" height="500" data-score-key="triangles"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="two_points"></canvas>
     <div id="strikes" class="strikes">
       <input type="checkbox" class="strike" disabled>
       <input type="checkbox" class="strike" disabled>
@@ -20,7 +20,7 @@
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>
-  <script type="module" src="triangles.js"></script>
+  <script type="module" src="two_points.js"></script>
   <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/two_points.js
+++ b/two_points.js
@@ -13,7 +13,7 @@ let attemptCount = 0;
 let strikes = 0;
 let shapesCompleted = 0;
 let totalAttempts = 0;
-let scoreKey = 'line_segments';
+let scoreKey = 'two_points';
 let attemptHasRed = false;
 let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
@@ -49,12 +49,12 @@ function drawGuesses() {
 function drawSegment(show = true) {
   clearCanvas(ctx);
   if (show) {
-    ctx.strokeStyle = 'black';
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    ctx.moveTo(vertices[0].x, vertices[0].y);
-    ctx.lineTo(vertices[1].x, vertices[1].y);
-    ctx.stroke();
+    ctx.fillStyle = 'black';
+    vertices.forEach(v => {
+      ctx.beginPath();
+      ctx.arc(v.x, v.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+    });
   }
   drawGuesses();
 }


### PR DESCRIPTION
## Summary
- show only vertices for two-, three-, and four-point drills
- rename drills to Two/Three/Four Points throughout menus and scenarios
- rename drill HTML/JS files to two_points, three_points, four_points and update references
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59dfbce248325a96ea96f318ef74c