### PR TITLE
feat: add new high score notification to leaderboard

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -1,6 +1,13 @@
 /** @jest-environment jsdom */
 
+import { jest } from '@jest/globals';
+
 describe('leaderboard display', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.resetModules();
+  });
+
   test('shows score and stats when provided', async () => {
     document.body.innerHTML = '<canvas></canvas>';
     window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
@@ -9,11 +16,11 @@ describe('leaderboard display', () => {
     const stats = document.querySelector('.leaderboard-stats');
     expect(stats).not.toBeNull();
     expect(stats.textContent).toBe('Accuracy: 75.5% | Avg time per target: 0.81s');
-    const formula = document.querySelector('.leaderboard-formula');
-    expect(formula).toBeNull();
+    const msg = document.querySelector('.leaderboard-new-high');
+    expect(msg).toBeNull();
   });
 
-  test('handleScore displays stats without formula', async () => {
+  test('handleScore shows new high score message', async () => {
     document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
     window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
     await import('../leaderboard.js');
@@ -22,7 +29,20 @@ describe('leaderboard display', () => {
     const stats = document.querySelector('.leaderboard-stats');
     expect(stats).not.toBeNull();
     expect(stats.textContent).toBe('Accuracy: 80.0% | Avg time per target: 0.50s');
-    const formula = document.querySelector('.leaderboard-formula');
-    expect(formula).toBeNull();
+    const msg = document.querySelector('.leaderboard-new-high');
+    expect(msg).not.toBeNull();
+    expect(msg.textContent).toBe('New high score!');
+  });
+
+  test('no new high score message when not exceeded', async () => {
+    document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score"></p>';
+    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+    await import('../leaderboard.js');
+    localStorage.setItem('playerName', 'Tester');
+    // set existing high score higher than current attempt
+    localStorage.setItem('leaderboard_point_drill_05', JSON.stringify({ Tester: 200 }));
+    window.leaderboard.handleScore('point_drill_05', 80, 80, 2);
+    const msg = document.querySelector('.leaderboard-new-high');
+    expect(msg).toBeNull();
   });
 });

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -15,10 +15,13 @@
     const storeKey = 'leaderboard_' + key;
     const data = JSON.parse(localStorage.getItem(storeKey)) || {};
     const current = data[name] || 0;
+    let isNew = false;
     if (score > current) {
       data[name] = score;
       localStorage.setItem(storeKey, JSON.stringify(data));
+      isNew = true;
     }
+    return isNew;
   }
 
   function getHighScore(key) {
@@ -28,7 +31,7 @@
     return scores.length ? Math.max(...scores) : 0;
   }
 
-  function showLeaderboard(key, playerScore, accuracy, speed) {
+  function showLeaderboard(key, playerScore, accuracy, speed, isNewHigh) {
     const storeKey = 'leaderboard_' + key;
     const data = JSON.parse(localStorage.getItem(storeKey)) || {};
     const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
@@ -65,6 +68,13 @@
         if (progress < 1) requestAnimationFrame(step);
       }
       requestAnimationFrame(step);
+    }
+
+    if (isNewHigh) {
+      const msg = document.createElement('p');
+      msg.className = 'leaderboard-new-high';
+      msg.textContent = 'New high score!';
+      overlay.appendChild(msg);
     }
 
     if (typeof accuracy === 'number' || typeof speed === 'number') {
@@ -131,8 +141,8 @@
   }
 
   function handleScore(key, score, accuracy, speed) {
-    updateLeaderboard(key, score);
-    showLeaderboard(key, score, accuracy, speed);
+    const isNew = updateLeaderboard(key, score);
+    showLeaderboard(key, score, accuracy, speed, isNew);
   }
 
   window.leaderboard = { handleScore, updateLeaderboard, showLeaderboard, getHighScore };

--- a/scenario.js
+++ b/scenario.js
@@ -84,8 +84,9 @@ function onShapeRevealed() {
   if (sEl) sEl.textContent = finalScore;
   const leaderboardKey = `scenario_${scenarioName}`;
   let high = 0;
+  let isNewHigh = false;
   if (window.leaderboard) {
-    window.leaderboard.updateLeaderboard(leaderboardKey, finalScore);
+    isNewHigh = window.leaderboard.updateLeaderboard(leaderboardKey, finalScore);
     high = window.leaderboard.getHighScore(leaderboardKey);
     const hEl = document.getElementById('highScoreValue');
     if (hEl) hEl.textContent = high.toString();
@@ -96,7 +97,10 @@ function onShapeRevealed() {
     if (window.leaderboard) {
       window.leaderboard.showLeaderboard(
         leaderboardKey,
-        finalScore
+        finalScore,
+        undefined,
+        undefined,
+        isNewHigh
       );
     }
     return;

--- a/style.css
+++ b/style.css
@@ -467,6 +467,13 @@ h2, h1 { margin: 10px 0; }
   margin: 10px 0;
 }
 
+.leaderboard-new-high {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #ffd700;
+  margin: 5px 0;
+}
+
 .leaderboard-buttons {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- highlight when a player sets a new high score on the leaderboard
- style "New high score!" banner
- update scenarios and tests for high score behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72df4e39483259b8c8a35ccd7bb25