### PR TITLE
Count freehand lines instead of pixels

### DIFF
--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -130,9 +130,9 @@ function endGame() {
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
-    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   } else {
-    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
 }
 
@@ -244,17 +244,17 @@ function pointerUp(e) {
   drawing = false;
   canvas.releasePointerCapture(e.pointerId);
   const total = onLineDist + offLineDist;
-  if (total > 0) {
-    stats.green += onLineDist;
-    stats.red += offLineDist;
+  if (total > 0 && activeTarget !== null) {
     const offRatio = offLineDist / total;
     const coverage = maxT - minT;
-    if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
+    if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
+      stats.green += 1;
       targets[activeTarget] = randomCurve();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
+      stats.red += 1;
     }
   }
   activeTarget = null;

--- a/dexterity_thick_contours.js
+++ b/dexterity_thick_contours.js
@@ -130,9 +130,9 @@ function endGame() {
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
-    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   } else {
-    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
 }
 
@@ -244,17 +244,17 @@ function pointerUp(e) {
   drawing = false;
   canvas.releasePointerCapture(e.pointerId);
   const total = onLineDist + offLineDist;
-  if (total > 0) {
-    stats.green += onLineDist;
-    stats.red += offLineDist;
+  if (total > 0 && activeTarget !== null) {
     const offRatio = offLineDist / total;
     const coverage = maxT - minT;
-    if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
+    if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
+      stats.green += 1;
       targets[activeTarget] = randomCurve();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
+      stats.red += 1;
     }
   }
   activeTarget = null;

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -95,9 +95,9 @@ function endGame() {
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
-    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   } else {
-    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
 }
 
@@ -188,17 +188,17 @@ function pointerUp(e) {
   drawing = false;
   canvas.releasePointerCapture(e.pointerId);
   const total = onLineDist + offLineDist;
-  if (total > 0) {
-    stats.green += onLineDist;
-    stats.red += offLineDist;
+  if (total > 0 && activeTarget !== null) {
     const offRatio = offLineDist / total;
     const coverage = maxT - minT;
-    if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
+    if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
+      stats.green += 1;
       targets[activeTarget] = randomLine();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
+      stats.red += 1;
     }
   }
   activeTarget = null;

--- a/dexterity_thin_lines.js
+++ b/dexterity_thin_lines.js
@@ -95,9 +95,9 @@ function endGame() {
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
-    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} (Best: ${high}) | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   } else {
-    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green.toFixed(0)} Red: ${stats.red.toFixed(0)}`;
+    result.textContent = `Score: ${finalScore} | Accuracy: ${accuracyPct.toFixed(1)}% | Speed: ${speed.toFixed(2)}/s | Green: ${stats.green} Red: ${stats.red}`;
   }
 }
 
@@ -188,17 +188,17 @@ function pointerUp(e) {
   drawing = false;
   canvas.releasePointerCapture(e.pointerId);
   const total = onLineDist + offLineDist;
-  if (total > 0) {
-    stats.green += onLineDist;
-    stats.red += offLineDist;
+  if (total > 0 && activeTarget !== null) {
     const offRatio = offLineDist / total;
     const coverage = maxT - minT;
-    if (activeTarget !== null && coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
+    if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
+      stats.green += 1;
       targets[activeTarget] = randomLine();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
+      stats.red += 1;
     }
   }
   activeTarget = null;


### PR DESCRIPTION
## Summary
- Count each freehand line as a single scored attempt across all line and contour drills
- Update results text to display line counts instead of pixel distances

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72f356b3c83259938e63f8c8673a1