### PR TITLE
feat: add high score reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <button id="drillsBtn">Drills</button>
     <button id="scenariosBtn">Scenarios</button>
     <button id="aboutBtn">About</button>
+    <button id="resetScoresBtn">Reset High Scores</button>
   </div>
   <script src="index.js"></script>
 </body>

--- a/index.js
+++ b/index.js
@@ -25,4 +25,29 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('aboutBtn')?.addEventListener('click', () => {
     window.location.href = 'about.html';
   });
+  document.getElementById('resetScoresBtn')?.addEventListener('click', () => {
+    if (!confirm('Reset all high scores?')) return;
+    try {
+      const remove = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (
+          key &&
+          (key.startsWith('leaderboard_') ||
+           key.startsWith('scenarioScore_') ||
+           key === 'p2pBest' ||
+           key === 'freehandBest')
+        ) {
+          remove.push(key);
+        }
+      }
+      remove.forEach(k => localStorage.removeItem(k));
+    } catch {
+      // Ignore errors if localStorage is unavailable
+    }
+    const p2pEl = document.getElementById('p2pBest');
+    const freeEl = document.getElementById('freehandBest');
+    if (p2pEl) p2pEl.textContent = 'N/A';
+    if (freeEl) freeEl.textContent = 'N/A';
+  });
 });


### PR DESCRIPTION
## Summary
- add menu button to reset high scores
- clear high score related localStorage keys when button clicked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7319a9ae883258e4b2fdff710587c