### PR TITLE
Show drill high scores on drills page

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -84,7 +84,7 @@
           <p>Guess randomly oriented angles in 10° steps.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_drill_05.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="point_drill_05.html" data-difficulty="Beginner" data-score-key="point_drill_05">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Points</span>
@@ -96,7 +96,7 @@
           <p>Memorize a point after a 0.5 second preview and tap its location.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_drill_025.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="point_drill_025.html" data-difficulty="Adept" data-score-key="point_drill_025">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Points</span>
@@ -108,7 +108,7 @@
           <p>Memorize a point after a 0.25 second preview and tap its location.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_drill_01.html" data-difficulty="Expert">
+      <div class="exercise-item" data-link="point_drill_01.html" data-difficulty="Expert" data-score-key="point_drill_01">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Points</span>
@@ -120,7 +120,7 @@
           <p>Memorize a point after a 0.1 second preview and tap its location.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_sequence_05.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="point_sequence_05.html" data-difficulty="Adept" data-score-key="point_sequence_05">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Points</span>
@@ -132,7 +132,7 @@
           <p>Memorize an expanding sequence of points after a 0.5 second preview.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_sequence_025.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="point_sequence_025.html" data-difficulty="Adept" data-score-key="point_sequence_025">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Points</span>
@@ -144,7 +144,7 @@
           <p>Memorize an expanding sequence of points after a 0.25 second preview.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_sequence_01.html" data-difficulty="Adept">
+      <div class="exercise-item" data-link="point_sequence_01.html" data-difficulty="Adept" data-score-key="point_sequence_01">
         <div class="tag-container">
             <span class="category-label category-memorization">Memorization</span>
           <span class="subject-label">Points</span>

--- a/drills.js
+++ b/drills.js
@@ -1,10 +1,16 @@
+function getHighScore(key) {
+  const data = JSON.parse(localStorage.getItem('leaderboard_' + key)) || {};
+  const scores = Object.values(data);
+  return scores.length ? Math.max(...scores) : 0;
+}
+
 function init() {
-  // Add high scores for dexterity drills
+  // Add high scores for drills
   document.querySelectorAll('.exercise-item[data-link]').forEach(item => {
     const info = item.querySelector('.exercise-info');
     const key = item.dataset.scoreKey;
     if (info && key) {
-      const val = localStorage.getItem(key) || 0;
+      const val = getHighScore(key);
       const p = document.createElement('p');
       p.className = 'high-score';
       p.textContent = `High Score: ${val}`;


### PR DESCRIPTION
## Summary
- display leaderboard high scores on drill cards
- connect point drill and sequence cards to their respective score keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b734272fe083259fd1525a378b1ba9