### PR TITLE
Add tag-based drill sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Shape Trainer is a small browser game where you try to memorize and recreate ran
 ## Running the Game
 
 1. Open `index.html` in any modern web browser. No build step or server is required—just open the file directly.
-2. The menu provides buttons for **Tutorial**, **Drills**, **Scenarios**, and **About**. The Drills menu combines memorization and dexterity exercises and includes a search bar.
+2. The menu provides buttons for **Tutorial**, **Drills**, **Scenarios**, and **About**. The Drills menu combines memorization and dexterity exercises and includes a search bar and tag filter dropdown.
 
 ## Basic Controls
 

--- a/drills.html
+++ b/drills.html
@@ -11,6 +11,9 @@
     <button id="backBtn">← Back</button>
     <h2>Drills</h2>
     <input id="searchInput" type="text" placeholder="Search drills..." />
+    <select id="tagSelect">
+      <option value="">All Tags</option>
+    </select>
     <div id="exerciseList" class="exercise-list">
       <div class="exercise-item" data-link="two_points.html" data-difficulty="Beginner" data-score-key="two_points">
         <div class="tag-container">

--- a/drills.js
+++ b/drills.js
@@ -15,16 +15,36 @@ function init() {
     });
   });
 
-  // Search filter
+  // Search and tag filter
   const search = document.getElementById('searchInput');
-  if (search) {
-    search.addEventListener('input', () => {
-      const term = search.value.toLowerCase();
-      document.querySelectorAll('.exercise-item').forEach(item => {
-        const title = item.querySelector('h3')?.textContent.toLowerCase() || '';
-        item.style.display = title.includes(term) ? '' : 'none';
-      });
+  const tagSelect = document.getElementById('tagSelect');
+
+  const filterList = () => {
+    const term = search?.value.toLowerCase() || '';
+    const selectedTag = tagSelect?.value || '';
+    document.querySelectorAll('.exercise-item').forEach(item => {
+      const title = item.querySelector('h3')?.textContent.toLowerCase() || '';
+      const tags = Array.from(item.querySelectorAll('.tag-container span')).map(span => span.textContent);
+      const matchesSearch = title.includes(term);
+      const matchesTag = !selectedTag || tags.includes(selectedTag);
+      item.style.display = matchesSearch && matchesTag ? '' : 'none';
     });
+  };
+
+  if (search) {
+    search.addEventListener('input', filterList);
+  }
+
+  if (tagSelect) {
+    const tags = new Set();
+    document.querySelectorAll('.exercise-item .tag-container span').forEach(span => tags.add(span.textContent));
+    tags.forEach(tag => {
+      const option = document.createElement('option');
+      option.value = tag;
+      option.textContent = tag;
+      tagSelect.appendChild(option);
+    });
+    tagSelect.addEventListener('change', filterList);
   }
 }
 


### PR DESCRIPTION
## Summary
- add tag filter dropdown to drill search UI
- implement combined text and tag filtering logic
- document tag filter in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b73456fadc83258f6720ae121ac6bb