### PR TITLE
Prevent short or off-canvas contours in dexterity drill

### DIFF
--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -25,6 +25,8 @@ const tolerance = 4;
 const maxOffSegmentRatio = 0.1;
 const LINE_WIDTH = 2;
 const SAMPLE_POINTS = 50;
+const MARGIN = 40;
+const MIN_CURVE_LEN = 200;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -37,15 +39,18 @@ function cubicBezier(p0, p1, p2, p3, t) {
 }
 
 function randomCurve() {
-  const margin = 40;
-  const x1 = Math.random() * (canvas.width - 2 * margin) + margin;
-  const y1 = Math.random() * (canvas.height - 2 * margin) + margin;
-  const x2 = Math.random() * (canvas.width - 2 * margin) + margin;
-  const y2 = Math.random() * (canvas.height - 2 * margin) + margin;
+  let x1, y1, x2, y2, dx, dy, len;
+  // Ensure the endpoints are a reasonable distance apart
+  do {
+    x1 = Math.random() * (canvas.width - 2 * MARGIN) + MARGIN;
+    y1 = Math.random() * (canvas.height - 2 * MARGIN) + MARGIN;
+    x2 = Math.random() * (canvas.width - 2 * MARGIN) + MARGIN;
+    y2 = Math.random() * (canvas.height - 2 * MARGIN) + MARGIN;
+    dx = x2 - x1;
+    dy = y2 - y1;
+    len = Math.hypot(dx, dy);
+  } while (len < MIN_CURVE_LEN);
 
-  const dx = x2 - x1;
-  const dy = y2 - y1;
-  const len = Math.hypot(dx, dy) || 1;
   const nx = -dy / len;
   const ny = dx / len;
   const offset = len * (0.3 + Math.random() * 0.2);
@@ -60,14 +65,20 @@ function randomCurve() {
     y: y1 + 2 * dy / 3 + ny * offset * (type === 'C' ? 1 : -1)
   };
 
+  // Keep the control points on the canvas so the curve doesn't go off-screen
+  cp1.x = Math.min(canvas.width - MARGIN, Math.max(MARGIN, cp1.x));
+  cp1.y = Math.min(canvas.height - MARGIN, Math.max(MARGIN, cp1.y));
+  cp2.x = Math.min(canvas.width - MARGIN, Math.max(MARGIN, cp2.x));
+  cp2.y = Math.min(canvas.height - MARGIN, Math.max(MARGIN, cp2.y));
+
   const points = [];
   for (let i = 0; i <= SAMPLE_POINTS; i++) {
-    points.push(cubicBezier({x:x1,y:y1}, cp1, cp2, {x:x2,y:y2}, i / SAMPLE_POINTS));
+    points.push(cubicBezier({ x: x1, y: y1 }, cp1, cp2, { x: x2, y: y2 }, i / SAMPLE_POINTS));
   }
   const segLengths = [];
   let totalLength = 0;
   for (let i = 0; i < points.length - 1; i++) {
-    const l = Math.hypot(points[i+1].x - points[i].x, points[i+1].y - points[i].y);
+    const l = Math.hypot(points[i + 1].x - points[i].x, points[i + 1].y - points[i].y);
     segLengths.push(l);
     totalLength += l;
   }


### PR DESCRIPTION
## Summary
- keep contour control points within canvas bounds
- ensure contours meet a minimum length before drawing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b85a6361b48325802abc4c3b5d83bf