### PR TITLE
Add animated realtime score counter

### DIFF
--- a/scenario.js
+++ b/scenario.js
@@ -29,6 +29,7 @@ let scenarioConfig = null;
 let scenarioName = '';
 let totalDuration = 0;
 let drawStartTime = 0;
+let displayedScore = 0;
 
 function toggleThreshold() {
   const wrapper = document.getElementById('thresholdWrapper');
@@ -47,6 +48,34 @@ function computeAverageError() {
     total += closest;
   });
   return total / playerShape.length;
+}
+
+function animateScoreChange(diff) {
+  const board = document.querySelector('.scoreboard');
+  if (!board || diff === 0) return;
+  const el = document.createElement('span');
+  el.className = `score-change ${diff >= 0 ? 'positive' : 'negative'}`;
+  el.textContent = (diff > 0 ? '+' : '') + diff;
+  board.appendChild(el);
+  el.addEventListener('animationend', () => el.remove());
+}
+
+function updateScore(newScore) {
+  const sEl = document.getElementById('scoreValue');
+  if (!sEl) return;
+  const start = displayedScore;
+  const diff = newScore - start;
+  const duration = 500;
+  const startTime = performance.now();
+  function step(now) {
+    const progress = Math.min((now - startTime) / duration, 1);
+    const value = Math.round(start + diff * progress);
+    sEl.textContent = value.toString();
+    if (progress < 1) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
+  animateScoreChange(diff);
+  displayedScore = newScore;
 }
 
 function onShapeRevealed() {
@@ -76,12 +105,11 @@ function onShapeRevealed() {
   const gEl = document.getElementById('greenCount');
   const yEl = document.getElementById('yellowCount');
   const rEl = document.getElementById('redCount');
-  const sEl = document.getElementById('scoreValue');
-  if (avgEl) avgEl.textContent = overall.toFixed(1);
-  if (gEl) gEl.textContent = scoreSummary.green;
-  if (yEl) yEl.textContent = scoreSummary.yellow;
-  if (rEl) rEl.textContent = scoreSummary.red;
-  if (sEl) sEl.textContent = finalScore;
+    if (avgEl) avgEl.textContent = overall.toFixed(1);
+    if (gEl) gEl.textContent = scoreSummary.green;
+    if (yEl) yEl.textContent = scoreSummary.yellow;
+    if (rEl) rEl.textContent = scoreSummary.red;
+    updateScore(finalScore);
   const leaderboardKey = `scenario_${scenarioName}`;
   let high = 0;
   let isNewHigh = false;
@@ -288,11 +316,12 @@ function startScenario(repeat = false) {
     const yEl = document.getElementById('yellowCount');
     const rEl = document.getElementById('redCount');
     const sEl = document.getElementById('scoreValue');
-    if (avgEl) avgEl.textContent = '0.0';
-    if (gEl) gEl.textContent = '0';
-    if (yEl) yEl.textContent = '0';
-    if (rEl) rEl.textContent = '0';
-    if (sEl) sEl.textContent = '0';
+      if (avgEl) avgEl.textContent = '0.0';
+      if (gEl) gEl.textContent = '0';
+      if (yEl) yEl.textContent = '0';
+      if (rEl) rEl.textContent = '0';
+      if (sEl) sEl.textContent = '0';
+      displayedScore = 0;
   }
 
   if (!repeat) {

--- a/scenario_play.html
+++ b/scenario_play.html
@@ -12,14 +12,16 @@
     <h2 id="scenarioTitle">Scenario</h2>
     <button id="startBtn">Start Challenge</button>
     <div class="play-area">
-      <canvas id="gameCanvas" width="500" height="500" data-score-key="scenario_play"></canvas>
-      <div class="scoreboard">
-        <p>Avg Error: <span id="avgError">0.0</span> px</p>
-        <p>Green: <span id="greenCount">0</span></p>
-        <p>Yellow: <span id="yellowCount">0</span></p>
-        <p>Red: <span id="redCount">0</span></p>
-        <p>Score: <span id="scoreValue">0</span></p>
-        <p>High Score: <span id="highScoreValue">0</span></p>
+      <div class="canvas-wrapper">
+        <canvas id="gameCanvas" width="500" height="500" data-score-key="scenario_play"></canvas>
+        <div class="scoreboard">
+          <p>Avg Error: <span id="avgError">0.0</span> px</p>
+          <p>Green: <span id="greenCount">0</span></p>
+          <p>Yellow: <span id="yellowCount">0</span></p>
+          <p>Red: <span id="redCount">0</span></p>
+          <p>Score: <span id="scoreValue">0</span></p>
+          <p>High Score: <span id="highScoreValue">0</span></p>
+        </div>
       </div>
     </div>
     <p class="score" id="result"></p>

--- a/style.css
+++ b/style.css
@@ -111,10 +111,39 @@ canvas {
   flex-direction: column;
   gap: 4px;
   font-weight: bold;
+  position: relative;
 }
 
 .scoreboard p {
   margin: 2px 0;
+  color: black;
+}
+
+.score-change {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-weight: bold;
+  animation: float-score 1s forwards;
+}
+
+.score-change.positive {
+  color: green;
+}
+
+.score-change.negative {
+  color: red;
+}
+
+@keyframes float-score {
+  from {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -20px);
+  }
 }
 .controls, .switches-group, .checkboxes-group {
   display: flex;


### PR DESCRIPTION
## Summary
- Display scoreboard beneath scenario canvas
- Animate score updates with floating color-coded deltas
- Provide CSS for floating score change effects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8615876608325b9b9168d2dfea747