### PR TITLE
Display score counters on drills

### DIFF
--- a/style.css
+++ b/style.css
@@ -162,7 +162,6 @@ canvas {
   text-align: center;
   font-weight: bold;
   min-height: 1.5em;
-  display: none;
 }
 .timer {
   text-align: center;


### PR DESCRIPTION
## Summary
- Show real-time score counters by removing CSS that hid `.score` elements.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b866f7ea588325aaf73ee6bc068589