### PR TITLE
Fix score counter not updating during scenario play

### DIFF
--- a/scenario.js
+++ b/scenario.js
@@ -259,7 +259,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const startBtn = document.getElementById('startBtn');
-  if (startBtn) {
+  if (startBtn && canvas) {
     overlayStartButton(canvas, startBtn);
     const params = new URLSearchParams(window.location.search);
     scenarioName = params.get('name') || 'default';


### PR DESCRIPTION
## Summary
- Guard scenario start overlay against missing canvas so script doesn't crash and the score counter updates in real time

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8bc9ef9d48325b753516e20538281