### PR TITLE
Add realtime scoring display for drills

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -1,6 +1,7 @@
 import { playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 const canvas = document.getElementById('angleCanvas');
 const ctx = canvas.getContext('2d');
@@ -53,6 +54,7 @@ function createOptions() {
 function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
+  startScoreboard(canvas);
   remainingAngles = [];
   for (let a = step; a <= 180; a += step) remainingAngles.push(a);
   currentAngle = null;
@@ -126,6 +128,7 @@ function onSelect(e) {
     total++;
     stats.green++;
     playSound(audioCtx, grade);
+    updateScoreboard('green');
     remainingAngles = remainingAngles.filter(a => a !== selected);
     const done = remainingAngles.length === 0;
     if (done) {
@@ -141,10 +144,12 @@ function onSelect(e) {
     grade = 'yellow';
     label.classList.add('close');
     stats.yellow++;
+    updateScoreboard('orange');
   } else {
     grade = 'red';
     label.classList.add('incorrect');
     stats.red++;
+    updateScoreboard('red');
   }
   total++;
   playSound(audioCtx, grade);

--- a/complex_shapes.js
+++ b/complex_shapes.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { generateShape, distancePointToSegment } from './geometry.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -273,6 +274,7 @@ function startGame() {
   startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
+  startScoreboard(canvas);
   startShape();
 }
 
@@ -319,6 +321,7 @@ function pointerUp() {
   if (grade === 'green') stats.green++;
   else if (grade === 'yellow') stats.yellow++;
   else stats.red++;
+  updateScoreboard(grade);
   attemptCount++;
 
   if (hadRed) {

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
@@ -118,6 +119,7 @@ function startGame() {
   audioCtx.resume();
   playing = true;
   stats = { green: 0, yellow: 0, red: 0 };
+  startScoreboard(canvas);
   startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
@@ -261,11 +263,13 @@ function pointerUp(e) {
     if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
       stats.green += 1;
+      updateScoreboard('green');
       targets[activeTarget] = randomCurve();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
       stats.red += 1;
+      updateScoreboard('red');
     }
   }
   activeTarget = null;

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
@@ -39,6 +40,7 @@ function startGame() {
   audioCtx.resume();
   playing = true;
   stats = { green: 0, yellow: 0, red: 0 };
+  startScoreboard(canvas);
   result.textContent = '';
   startBtn.disabled = true;
   targets = [randomTarget(), randomTarget()];
@@ -77,6 +79,7 @@ function pointerDown(e) {
     const d = Math.hypot(pos.x - t.x, pos.y - t.y);
     if (d <= gradingTolerance) {
       stats.green++;
+      updateScoreboard('green');
       hit = true;
       setTimeout(() => playSound(audioCtx, 'green'), 0);
       targets[i] = randomTarget();
@@ -87,6 +90,7 @@ function pointerDown(e) {
   if (!hit) {
     stats.red++;
     setTimeout(() => playSound(audioCtx, 'red'), 0);
+    updateScoreboard('red');
   }
 }
 

--- a/dexterity_thick_contours.js
+++ b/dexterity_thick_contours.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
@@ -107,6 +108,7 @@ function startGame() {
   audioCtx.resume();
   playing = true;
   stats = { green: 0, yellow: 0, red: 0 };
+  startScoreboard(canvas);
   startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
@@ -250,11 +252,13 @@ function pointerUp(e) {
     if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
       stats.green += 1;
+      updateScoreboard('green');
       targets[activeTarget] = randomCurve();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
       stats.red += 1;
+      updateScoreboard('red');
     }
   }
   activeTarget = null;

--- a/dexterity_thick_lines.js
+++ b/dexterity_thick_lines.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
@@ -72,6 +73,7 @@ function startGame() {
   audioCtx.resume();
   playing = true;
   stats = { green: 0, yellow: 0, red: 0 };
+  startScoreboard(canvas);
   startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
@@ -194,11 +196,13 @@ function pointerUp(e) {
     if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
       stats.green += 1;
+      updateScoreboard('green');
       targets[activeTarget] = randomLine();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
       stats.red += 1;
+      updateScoreboard('red');
     }
   }
   activeTarget = null;

--- a/dexterity_thin_lines.js
+++ b/dexterity_thin_lines.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
@@ -72,6 +73,7 @@ function startGame() {
   audioCtx.resume();
   playing = true;
   stats = { green: 0, yellow: 0, red: 0 };
+  startScoreboard(canvas);
   startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
@@ -194,11 +196,13 @@ function pointerUp(e) {
     if (coverage >= 0.9 && offRatio <= maxOffSegmentRatio) {
       playSound(audioCtx, 'green');
       stats.green += 1;
+      updateScoreboard('green');
       targets[activeTarget] = randomLine();
       drawTargets();
     } else {
       playSound(audioCtx, 'red');
       stats.red += 1;
+      updateScoreboard('red');
     }
   }
   activeTarget = null;

--- a/four_points.js
+++ b/four_points.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { generateShape } from './geometry.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -141,6 +142,7 @@ function pointerDown(e) {
     if (grade === 'green') stats.green++;
     else if (grade === 'yellow') stats.yellow++;
     else stats.red++;
+    updateScoreboard(grade);
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
@@ -154,6 +156,7 @@ function pointerDown(e) {
     if (grade === 'green') stats.green++;
     else if (grade === 'yellow') stats.yellow++;
     else stats.red++;
+    updateScoreboard(grade);
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
@@ -187,6 +190,7 @@ function startGame() {
   startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
+  startScoreboard(canvas);
   startQuadrilateral();
 }
 

--- a/point_drill_01.js
+++ b/point_drill_01.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerDisplay;
 
@@ -73,6 +74,7 @@ function pointerDown(e) {
   }
   const prevTarget = target;
   playSound(audioCtx, grade);
+  updateScoreboard(grade === 'yellow' ? 'orange' : grade);
   if (Date.now() < endTime) {
     drawTarget();
   }
@@ -85,6 +87,7 @@ function pointerDown(e) {
 function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
+  startScoreboard(canvas);
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
   awaitingClick = false;

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerDisplay;
 
@@ -73,6 +74,7 @@ function pointerDown(e) {
   }
   const prevTarget = target;
   playSound(audioCtx, grade);
+  updateScoreboard(grade === 'yellow' ? 'orange' : grade);
   if (Date.now() < endTime) {
     drawTarget();
   }
@@ -85,6 +87,7 @@ function pointerDown(e) {
 function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
+  startScoreboard(canvas);
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
   awaitingClick = false;

--- a/point_drill_05.js
+++ b/point_drill_05.js
@@ -2,6 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { hideStartButton } from './src/start-button.js';
 import { startCountdown } from './src/countdown.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, timerDisplay;
 
@@ -73,6 +74,7 @@ function pointerDown(e) {
   }
   const prevTarget = target;
   playSound(audioCtx, grade);
+  updateScoreboard(grade === 'yellow' ? 'orange' : grade);
   if (Date.now() < endTime) {
     drawTarget();
   }
@@ -85,6 +87,7 @@ function pointerDown(e) {
 function startGame() {
   hideStartButton(startBtn);
   audioCtx.resume();
+  startScoreboard(canvas);
   stats = { totalErr: 0, totalPoints: 0, green: 0, yellow: 0, red: 0 };
   playing = true;
   awaitingClick = false;

--- a/point_sequence.js
+++ b/point_sequence.js
@@ -1,6 +1,7 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, strikeElems;
 let lookTime = 500;
@@ -118,6 +119,7 @@ function pointerDown(e) {
   stats[grade]++;
   const color = grade === 'yellow' ? 'orange' : grade;
   guesses.push({ pos, color });
+  updateScoreboard(color);
   playSound(audioCtx, grade);
   if (grade !== 'green') {
     drawFeedbackPoint(feedbackCtx, pos, color);
@@ -156,6 +158,7 @@ function startGame() {
   strikes = 0;
   updateStrikes();
   stats = { green: 0, yellow: 0, red: 0 };
+  startScoreboard(canvas);
   sequence = [];
   inputIndex = 0;
   startTime = Date.now();

--- a/src/scoreboard.js
+++ b/src/scoreboard.js
@@ -1,0 +1,37 @@
+import { calculateScore } from './scoring.js';
+
+let stats = { green: 0, yellow: 0, red: 0 };
+let startTime = 0;
+let scoreEl = null;
+
+export function startScoreboard(canvas) {
+  let board = canvas?.nextElementSibling;
+  if (!board || !board.classList.contains('scoreboard')) {
+    board = document.createElement('div');
+    board.className = 'scoreboard';
+    const p = document.createElement('p');
+    p.innerHTML = 'Score: <span class="score-value">0</span>';
+    board.appendChild(p);
+    canvas.insertAdjacentElement('afterend', board);
+  }
+  scoreEl = board.querySelector('.score-value');
+  scoreEl.textContent = '0';
+  stats = { green: 0, yellow: 0, red: 0 };
+  startTime = Date.now();
+}
+
+export function updateScoreboard(color) {
+  if (!scoreEl) return;
+  if (color === 'green') stats.green++;
+  else if (color === 'yellow' || color === 'orange') stats.yellow++;
+  else stats.red++;
+  const elapsed = Date.now() - startTime;
+  const { score } = calculateScore(stats, elapsed);
+  scoreEl.textContent = score.toString();
+}
+
+export function getCurrentScore() {
+  const elapsed = Date.now() - startTime;
+  const { score } = calculateScore(stats, elapsed);
+  return score;
+}

--- a/three_points.js
+++ b/three_points.js
@@ -1,6 +1,7 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -158,6 +159,7 @@ function pointerDown(e) {
     if (grade === 'green') stats.green++;
     else if (grade === 'yellow') stats.yellow++;
     else stats.red++;
+    updateScoreboard(grade);
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
@@ -171,6 +173,7 @@ function pointerDown(e) {
     if (grade === 'green') stats.green++;
     else if (grade === 'yellow') stats.yellow++;
     else stats.red++;
+    updateScoreboard(grade);
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
@@ -204,6 +207,7 @@ function startGame() {
   startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
+  startScoreboard(canvas);
   startTriangle();
 }
 

--- a/two_points.js
+++ b/two_points.js
@@ -1,6 +1,7 @@
 import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
+import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
 
 let canvas, ctx, startBtn, result, strikeElems;
 let playing = false;
@@ -150,6 +151,7 @@ function pointerDown(e) {
     if (grade === 'green') stats.green++;
     else if (grade === 'yellow') stats.yellow++;
     else stats.red++;
+    updateScoreboard(grade);
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     state = 'guess';
@@ -163,6 +165,7 @@ function pointerDown(e) {
     if (grade === 'green') stats.green++;
     else if (grade === 'yellow') stats.yellow++;
     else stats.red++;
+    updateScoreboard(grade);
     playSound(audioCtx, grade);
     remaining.splice(remaining.indexOf(idx), 1);
     clearCanvas(ctx);
@@ -196,6 +199,7 @@ function startGame() {
   startTime = Date.now();
   scoreKey = canvas.dataset.scoreKey || scoreKey;
   updateStrikes();
+  startScoreboard(canvas);
   startSegment();
 }
 


### PR DESCRIPTION
## Summary
- Introduce reusable scoreboard module that calculates and renders the current score under the canvas
- Hook up two-, three-, and four-point drills as well as complex shapes drill to update the scoreboard after every graded action
- Extend live scoreboard support to remaining drills including angles, dexterity challenges, and timed point sequences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8bf811f208325a9d1b8edb4126150