### PR TITLE
Enhance score counter with centered layout and change animations

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,11 +112,27 @@ canvas {
   gap: 4px;
   font-weight: bold;
   position: relative;
+  align-items: center;
+  margin: 10px auto 0;
+  font-size: 24px;
+  text-align: center;
 }
 
 .scoreboard p {
   margin: 2px 0;
+}
+
+.scoreboard .score-value {
   color: black;
+  transition: color 0.3s;
+}
+
+.scoreboard .score-value.increase {
+  color: green;
+}
+
+.scoreboard .score-value.decrease {
+  color: red;
 }
 
 .score-change {


### PR DESCRIPTION
## Summary
- Center and enlarge score counter below canvas
- Drop "Score:" label from counter display
- Animate score changes with floating +/– indicators
- Flash score green on gains and red on losses
- Animate score value counting up or down to new totals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c3ae62e48325a9693d6420bea700