### PR TITLE
Treat orange grades as zero points

### DIFF
--- a/__tests__/scoring.test.js
+++ b/__tests__/scoring.test.js
@@ -6,4 +6,10 @@ describe('calculateScore', () => {
     const many = calculateScore({ green: 5, yellow: 0, red: 0 }, 5000);
     expect(many.score).toBeGreaterThan(one.score);
   });
+
+  test('yellow grades do not increase score', () => {
+    const withYellow = calculateScore({ green: 1, yellow: 1, red: 0 }, 1000);
+    const withoutYellow = calculateScore({ green: 1, yellow: 0, red: 0 }, 1000);
+    expect(withYellow.score).toBeLessThanOrEqual(withoutYellow.score);
+  });
 });

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -3,8 +3,8 @@ export function calculateScore(stats, durationMs) {
   const yellow = stats.yellow || 0;
   const red = stats.red || 0;
   const total = green + yellow + red;
-  const completed = green + yellow * 0.5;
-  const accuracy = total ? (green + yellow * 0.5) / total : 0;
+  const completed = green;
+  const accuracy = total ? green / total : 0;
   const accuracyPct = accuracy * 100;
   const seconds = durationMs > 0 ? durationMs / 1000 : 0;
   const speed = seconds > 0 ? green / seconds : 0;


### PR DESCRIPTION
## Summary
- Remove yellow/"orange" credit from score calculation so only green grades contribute points
- Guard against yellow grades increasing score with a dedicated unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8ead7b22883259c0d7d5f3a08488e