### PR TITLE
Hide duplicate score text when drill completes

### DIFF
--- a/__tests__/leaderboard.test.js
+++ b/__tests__/leaderboard.test.js
@@ -63,4 +63,15 @@ describe('leaderboard display', () => {
     expect(msg).not.toBeNull();
     expect(msg.textContent).toBe('New high score!');
   });
+
+  test('score element hidden after leaderboard displayed', async () => {
+    document.body.innerHTML = '<canvas data-score-key="point_drill_05"></canvas><p class="score">Score: 0</p>';
+    window.requestAnimationFrame = cb => cb(Number.MAX_SAFE_INTEGER);
+    await import('../leaderboard.js');
+    localStorage.setItem('playerName', 'Tester');
+    window.leaderboard.handleScore('point_drill_05', 80, 80, 2);
+    const result = document.querySelector('.score');
+    expect(result.textContent).toBe('');
+    expect(result.style.display).toBe('none');
+  });
 });

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -143,6 +143,12 @@
     overlay.appendChild(buttons);
 
     document.body.appendChild(overlay);
+
+    const resultEl = document.querySelector('.score');
+    if (resultEl) {
+      resultEl.textContent = '';
+      resultEl.style.display = 'none';
+    }
   }
 
   function handleScore(key, score, accuracy, speed) {


### PR DESCRIPTION
## Summary
- Clear and hide under-canvas score element after leaderboard overlay is shown
- Add regression test to ensure the score text is hidden when a drill ends

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8eb2742e88325ae44ac8187e1666e