### PR TITLE
Remove delay after successful point drills

### DIFF
--- a/four_points.js
+++ b/four_points.js
@@ -21,7 +21,6 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_QUADRILATERAL_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateQuadrilateral() {
@@ -98,18 +97,11 @@ function finishCycle() {
   if (success) {
     shapesCompleted++;
     totalAttempts += attemptCount;
-    result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
-    setTimeout(() => {
-      guessesGreyed = true;
-      drawQuadrilateral(true);
-    }, SHOW_COLOR_TIME);
-    setTimeout(() => {
-      result.textContent = '';
-      attemptCount = 0;
-      strikes = 0;
-      updateStrikes();
-      startQuadrilateral();
-    }, NEW_QUADRILATERAL_DELAY);
+    result.textContent = '';
+    attemptCount = 0;
+    strikes = 0;
+    updateStrikes();
+    startQuadrilateral();
   } else {
     if (attemptHasRed) {
       strikes++;

--- a/three_points.js
+++ b/three_points.js
@@ -20,7 +20,6 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_TRIANGLE_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateTriangle() {
@@ -115,18 +114,11 @@ function finishCycle() {
   if (success) {
     shapesCompleted++;
     totalAttempts += attemptCount;
-    result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
-    setTimeout(() => {
-      guessesGreyed = true;
-      drawTriangle(true);
-    }, SHOW_COLOR_TIME);
-    setTimeout(() => {
-      result.textContent = '';
-      attemptCount = 0;
-      strikes = 0;
-      updateStrikes();
-      startTriangle();
-    }, NEW_TRIANGLE_DELAY);
+    result.textContent = '';
+    attemptCount = 0;
+    strikes = 0;
+    updateStrikes();
+    startTriangle();
   } else {
     if (attemptHasRed) {
       strikes++;

--- a/two_points.js
+++ b/two_points.js
@@ -20,7 +20,6 @@ let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;
 
 const SHOW_COLOR_TIME = 500;
-const NEW_SEGMENT_DELAY = 1000;
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
 function generateSegment() {
@@ -107,18 +106,11 @@ function finishCycle() {
   if (success) {
     shapesCompleted++;
     totalAttempts += attemptCount;
-    result.textContent = `Completed in ${attemptCount} ${attemptCount === 1 ? 'try' : 'tries'}!`;
-    setTimeout(() => {
-      guessesGreyed = true;
-      drawSegment(true);
-    }, SHOW_COLOR_TIME);
-    setTimeout(() => {
-      result.textContent = '';
-      attemptCount = 0;
-      strikes = 0;
-      updateStrikes();
-      startSegment();
-    }, NEW_SEGMENT_DELAY);
+    result.textContent = '';
+    attemptCount = 0;
+    strikes = 0;
+    updateStrikes();
+    startSegment();
   } else {
     if (attemptHasRed) {
       strikes++;


### PR DESCRIPTION
## Summary
- Start next point set immediately after correct answers in two, three, and four point drills
- Drop unused post-success delay constants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68befe01c0ac8325a2c7ad49ceb5ccd1