### PR TITLE
Remove 0.25 and 0.1 second point sequence drills

### DIFF
--- a/back.js
+++ b/back.js
@@ -23,8 +23,6 @@ document.addEventListener('DOMContentLoaded', () => {
     'point_drill_025.html': { label: 'Drills', target: 'drills.html' },
     'point_drill_05.html': { label: 'Drills', target: 'drills.html' },
     'point_sequence_05.html': { label: 'Drills', target: 'drills.html' },
-    'point_sequence_025.html': { label: 'Drills', target: 'drills.html' },
-    'point_sequence_01.html': { label: 'Drills', target: 'drills.html' },
     'inch_warmup.html': { label: 'Drills', target: 'drills.html' }
   };
 

--- a/drills.html
+++ b/drills.html
@@ -135,35 +135,11 @@
           <p>Memorize an expanding sequence of points after a 0.5 second preview.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="point_sequence_025.html" data-difficulty="Adept" data-score-key="point_sequence_025">
+      <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
         <div class="tag-container">
-            <span class="category-label category-memorization">Memorization</span>
-          <span class="subject-label">Points</span>
-          <span class="difficulty-label difficulty-adept">Adept</span>
-        </div>
-        <img class="exercise-gif" alt="" />
-        <div class="exercise-info">
-          <h3>Point Sequence 0.25 sec Look</h3>
-          <p>Memorize an expanding sequence of points after a 0.25 second preview.</p>
-        </div>
-      </div>
-      <div class="exercise-item" data-link="point_sequence_01.html" data-difficulty="Adept" data-score-key="point_sequence_01">
-        <div class="tag-container">
-            <span class="category-label category-memorization">Memorization</span>
-          <span class="subject-label">Points</span>
-          <span class="difficulty-label difficulty-adept">Adept</span>
-        </div>
-        <img class="exercise-gif" alt="" />
-        <div class="exercise-info">
-          <h3>Point Sequence 0.1 sec Look</h3>
-          <p>Memorize an expanding sequence of points after a 0.1 second preview.</p>
-        </div>
-      </div>
-        <div class="exercise-item" data-link="dexterity_point_drill_large.html" data-difficulty="Beginner" data-score-key="dexterity_point_drill_large">
-          <div class="tag-container">
-              <span class="category-label category-dexterity">Dexterity</span>
-              <span class="subject-label">Points</span>
-              <span class="difficulty-label difficulty-beginner">Beginner</span>
+            <span class="category-label category-dexterity">Dexterity</span>
+            <span class="subject-label">Points</span>
+            <span class="difficulty-label difficulty-beginner">Beginner</span>
           </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">

--- a/drills_data.js
+++ b/drills_data.js
@@ -9,8 +9,6 @@ export const drills = [
   { name: 'Point Drill 0.25 sec Look', url: 'point_drill_025.html', description: 'Memorize a point after a 0.25 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
   { name: 'Point Drill 0.1 sec Look', url: 'point_drill_01.html', description: 'Memorize a point after a 0.1 second preview and tap its location.', category: 'Memorization', subject: 'Points', difficulty: 'Expert' },
   { name: 'Point Sequence 0.5 sec Look', url: 'point_sequence_05.html', description: 'Memorize an expanding sequence of points after a 0.5 second preview.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
-  { name: 'Point Sequence 0.25 sec Look', url: 'point_sequence_025.html', description: 'Memorize an expanding sequence of points after a 0.25 second preview.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
-  { name: 'Point Sequence 0.1 sec Look', url: 'point_sequence_01.html', description: 'Memorize an expanding sequence of points after a 0.1 second preview.', category: 'Memorization', subject: 'Points', difficulty: 'Adept' },
   { name: 'Large Points', url: 'dexterity_point_drill_large.html', description: 'Point drill with larger targets for easier accuracy.', category: 'Dexterity', subject: 'Points', difficulty: 'Beginner' },
   { name: 'Medium Points', url: 'dexterity_point_drill.html', description: 'Improve pointer accuracy with rapid taps.', category: 'Dexterity', subject: 'Points', difficulty: 'Adept' },
   { name: 'Small Points', url: 'dexterity_point_drill_small.html', description: 'Point drill with smaller targets for higher precision.', category: 'Dexterity', subject: 'Points', difficulty: 'Expert' },

--- a/scenarios.js
+++ b/scenarios.js
@@ -41,18 +41,6 @@ export const scenarioData = {
     difficulty: 'Adept',
     subject: 'Points'
   },
-  "Point Sequence 0.25 sec Look": {
-    url: 'point_sequence_025.html',
-    description: 'Memorize an expanding sequence of points after a 0.25 second preview.',
-    difficulty: 'Adept',
-    subject: 'Points'
-  },
-  "Point Sequence 0.1 sec Look": {
-    url: 'point_sequence_01.html',
-    description: 'Memorize an expanding sequence of points after a 0.1 second preview.',
-    difficulty: 'Adept',
-    subject: 'Points'
-  },
   "Three Points": {
     url: 'three_points.html',
     description: 'Memorize three points.',


### PR DESCRIPTION
## Summary
- remove 0.25s and 0.1s point sequence drills from drills page
- drop corresponding entries from drills data and scenarios
- update back button config accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beff2c7eb083258e60f4d69b07e5c3