### PR TITLE
Add scenario editing capability

### DIFF
--- a/scenarios.html
+++ b/scenarios.html
@@ -11,6 +11,7 @@
     <button id="backBtn">← Main Menu</button>
     <h2>Scenarios</h2>
     <button id="newScenarioBtn">New Scenario</button>
+    <button id="editScenarioBtn">Edit Scenario</button>
     <div id="scenarioList" class="exercise-list"></div>
   </div>
   <div id="builderScreen" class="menu-screen" style="display:none;">


### PR DESCRIPTION
## Summary
- Add an Edit Scenario button to the Scenarios page
- Introduce edit mode and functions to load and save existing scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16ec704dc832584ca5941ead38b20