### PR TITLE
Remove thick line drills from drill list

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -183,18 +183,6 @@
           <p>Point drill with smaller targets for higher precision.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_thick_lines.html" data-difficulty="Beginner" data-score-key="dexterity_thick_lines">
-        <div class="tag-container">
-              <span class="category-label category-dexterity">Dexterity</span>
-            <span class="subject-label">Lines</span>
-            <span class="difficulty-label difficulty-beginner">Beginner</span>
-        </div>
-        <img class="exercise-gif" alt="" />
-        <div class="exercise-info">
-          <h3>Thick Lines</h3>
-          <p>Trace thicker lines for an easier challenge.</p>
-        </div>
-      </div>
       <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
         <div class="tag-container">
               <span class="category-label category-dexterity">Dexterity</span>
@@ -205,18 +193,6 @@
         <div class="exercise-info">
           <h3>Thin Lines</h3>
           <p>Practice tracing thin lines of different lengths and directions.</p>
-        </div>
-      </div>
-      <div class="exercise-item" data-link="dexterity_thick_contours.html" data-difficulty="Adept" data-score-key="dexterity_thick_contours">
-        <div class="tag-container">
-              <span class="category-label category-dexterity">Dexterity</span>
-            <span class="subject-label">Lines</span>
-            <span class="difficulty-label difficulty-adept">Adept</span>
-        </div>
-        <img class="exercise-gif" alt="" />
-        <div class="exercise-info">
-          <h3>Thick Contours</h3>
-          <p>Trace thick C and S curves for smoother control.</p>
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_contours.html" data-difficulty="Expert" data-score-key="dexterity_contours">

--- a/drills_data.js
+++ b/drills_data.js
@@ -13,8 +13,6 @@ export const drills = [
   { name: 'Large Points', url: 'dexterity_point_drill_large.html', description: 'Point drill with larger targets for easier accuracy.', category: 'Dexterity', subject: 'Points', difficulty: 'Beginner' },
   { name: 'Medium Points', url: 'dexterity_point_drill.html', description: 'Improve pointer accuracy with rapid taps.', category: 'Dexterity', subject: 'Points', difficulty: 'Adept' },
   { name: 'Small Points', url: 'dexterity_point_drill_small.html', description: 'Point drill with smaller targets for higher precision.', category: 'Dexterity', subject: 'Points', difficulty: 'Expert' },
-  { name: 'Thick Lines', url: 'dexterity_thick_lines.html', description: 'Trace thicker lines for an easier challenge.', category: 'Dexterity', subject: 'Lines', difficulty: 'Beginner' },
   { name: 'Thin Lines', url: 'dexterity_thin_lines.html', description: 'Practice tracing thin lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
-  { name: 'Thick Contours', url: 'dexterity_thick_contours.html', description: 'Trace thick C and S curves for smoother control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
   { name: 'Contours', url: 'dexterity_contours.html', description: 'Trace C and S shaped curves for advanced control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Expert' }
 ];


### PR DESCRIPTION
## Summary
- Drop Thick Lines drill from drills page and data set
- Drop Thick Contours drill to keep list focused on thin lines and contours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e3879c08832594dfd942ffbd00aa