### PR TITLE
Rename thin lines drill to Lines

### DIFF
--- a/back.js
+++ b/back.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'dexterity_contours.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_thick_contours.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_thick_lines.html': { label: 'Drills', target: 'drills.html' },
-    'dexterity_thin_lines.html': { label: 'Drills', target: 'drills.html' },
+    'dexterity_lines.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_point_drill.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_point_drill_large.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_point_drill_small.html': { label: 'Drills', target: 'drills.html' },

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -21,7 +21,7 @@ let lastPos = null;
 let offLineDist = 0;
 let onLineDist = 0;
 
-// Match grading parameters with dexterity_thin_lines.js
+// Match grading parameters with dexterity_lines.js
 const tolerance = 4;
 const maxOffSegmentRatio = 0.1;
 const LINE_WIDTH = 2;

--- a/dexterity_lines.html
+++ b/dexterity_lines.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Thin Lines - Memory Shape Drawing Game</title>
+  <title>Lines - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="practice-screen">
     <button id="backBtn">← Back</button>
-    <h2>Thin Lines</h2>
+    <h2>Lines</h2>
     <button id="startBtn">Start</button>
     <p class="timer" id="timer">60.00</p>
-    <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thin_lines"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_lines"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>
-  <script type="module" src="dexterity_thin_lines.js"></script>
+  <script type="module" src="dexterity_lines.js"></script>
   <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_lines.js
+++ b/dexterity_lines.js
@@ -8,7 +8,7 @@ let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let gameTimer = null;
-let scoreKey = 'dexterity_thin_lines';
+let scoreKey = 'dexterity_lines';
 let stopTimer = null;
 let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;

--- a/drills.html
+++ b/drills.html
@@ -195,7 +195,7 @@
           <p>Trace thicker lines for an easier challenge.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
+      <div class="exercise-item" data-link="dexterity_lines.html" data-difficulty="Adept" data-score-key="dexterity_lines">
         <div class="tag-container">
               <span class="category-label category-dexterity">Dexterity</span>
             <span class="subject-label">Lines</span>
@@ -203,8 +203,8 @@
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Thin Lines</h3>
-          <p>Practice tracing thin lines of different lengths and directions.</p>
+          <h3>Lines</h3>
+          <p>Practice tracing lines of different lengths and directions.</p>
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_thick_contours.html" data-difficulty="Adept" data-score-key="dexterity_thick_contours">

--- a/drills_data.js
+++ b/drills_data.js
@@ -14,7 +14,7 @@ export const drills = [
   { name: 'Medium Points', url: 'dexterity_point_drill.html', description: 'Improve pointer accuracy with rapid taps.', category: 'Dexterity', subject: 'Points', difficulty: 'Adept' },
   { name: 'Small Points', url: 'dexterity_point_drill_small.html', description: 'Point drill with smaller targets for higher precision.', category: 'Dexterity', subject: 'Points', difficulty: 'Expert' },
   { name: 'Thick Lines', url: 'dexterity_thick_lines.html', description: 'Trace thicker lines for an easier challenge.', category: 'Dexterity', subject: 'Lines', difficulty: 'Beginner' },
-  { name: 'Thin Lines', url: 'dexterity_thin_lines.html', description: 'Practice tracing thin lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
+  { name: 'Lines', url: 'dexterity_lines.html', description: 'Practice tracing lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
   { name: 'Thick Contours', url: 'dexterity_thick_contours.html', description: 'Trace thick C and S curves for smoother control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
   { name: 'Contours', url: 'dexterity_contours.html', description: 'Trace C and S shaped curves for advanced control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Expert' }
 ];


### PR DESCRIPTION
## Summary
- Rename thin lines drill to Lines and adjust score key
- Update drill listings, metadata, and navigation for renamed drill
- Align contour drill comment with new file name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e40ea0fc832589066ad4d29a62c5