### PR TITLE
Rename thin lines drill to lines

### DIFF
--- a/back.js
+++ b/back.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'dexterity_contours.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_thick_contours.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_thick_lines.html': { label: 'Drills', target: 'drills.html' },
-    'dexterity_thin_lines.html': { label: 'Drills', target: 'drills.html' },
+    'dexterity_lines.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_point_drill.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_point_drill_large.html': { label: 'Drills', target: 'drills.html' },
     'dexterity_point_drill_small.html': { label: 'Drills', target: 'drills.html' },

--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -21,7 +21,7 @@ let lastPos = null;
 let offLineDist = 0;
 let onLineDist = 0;
 
-// Match grading parameters with dexterity_thin_lines.js
+// Match grading parameters with dexterity_lines.js
 const tolerance = 4;
 const maxOffSegmentRatio = 0.1;
 const LINE_WIDTH = 2;

--- a/dexterity_lines.html
+++ b/dexterity_lines.html
@@ -3,20 +3,20 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Thin Lines - Memory Shape Drawing Game</title>
+  <title>Lines - Memory Shape Drawing Game</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="practice-screen">
     <button id="backBtn">← Back</button>
-    <h2>Thin Lines</h2>
+    <h2>Lines</h2>
     <button id="startBtn">Start</button>
     <p class="timer" id="timer">60.00</p>
-    <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_thin_lines"></canvas>
+    <canvas id="gameCanvas" width="500" height="500" data-score-key="dexterity_lines"></canvas>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>
-  <script type="module" src="dexterity_thin_lines.js"></script>
+  <script type="module" src="dexterity_lines.js"></script>
   <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/dexterity_lines.js
+++ b/dexterity_lines.js
@@ -8,7 +8,7 @@ let canvas, ctx, startBtn, result, timerDisplay;
 let playing = false;
 let targets = [];
 let gameTimer = null;
-let scoreKey = 'dexterity_thin_lines';
+let scoreKey = 'dexterity_lines';
 let stopTimer = null;
 let stats = { green: 0, yellow: 0, red: 0 };
 let startTime = 0;

--- a/drills.html
+++ b/drills.html
@@ -183,7 +183,7 @@
           <p>Point drill with smaller targets for higher precision.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="dexterity_thin_lines.html" data-difficulty="Adept" data-score-key="dexterity_thin_lines">
+      <div class="exercise-item" data-link="dexterity_lines.html" data-difficulty="Adept" data-score-key="dexterity_lines">
         <div class="tag-container">
               <span class="category-label category-dexterity">Dexterity</span>
             <span class="subject-label">Lines</span>
@@ -191,8 +191,8 @@
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">
-          <h3>Thin Lines</h3>
-          <p>Practice tracing thin lines of different lengths and directions.</p>
+          <h3>Lines</h3>
+          <p>Practice tracing lines of different lengths and directions.</p>
         </div>
       </div>
       <div class="exercise-item" data-link="dexterity_contours.html" data-difficulty="Expert" data-score-key="dexterity_contours">

--- a/drills_data.js
+++ b/drills_data.js
@@ -13,6 +13,6 @@ export const drills = [
   { name: 'Large Points', url: 'dexterity_point_drill_large.html', description: 'Point drill with larger targets for easier accuracy.', category: 'Dexterity', subject: 'Points', difficulty: 'Beginner' },
   { name: 'Medium Points', url: 'dexterity_point_drill.html', description: 'Improve pointer accuracy with rapid taps.', category: 'Dexterity', subject: 'Points', difficulty: 'Adept' },
   { name: 'Small Points', url: 'dexterity_point_drill_small.html', description: 'Point drill with smaller targets for higher precision.', category: 'Dexterity', subject: 'Points', difficulty: 'Expert' },
-  { name: 'Thin Lines', url: 'dexterity_thin_lines.html', description: 'Practice tracing thin lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
+  { name: 'Lines', url: 'dexterity_lines.html', description: 'Practice tracing lines of different lengths and directions.', category: 'Dexterity', subject: 'Lines', difficulty: 'Adept' },
   { name: 'Contours', url: 'dexterity_contours.html', description: 'Trace C and S shaped curves for advanced control.', category: 'Dexterity', subject: 'Lines', difficulty: 'Expert' }
 ];


### PR DESCRIPTION
## Summary
- Rename Thin Lines drill to Lines, updating filenames, labels, and score key
- Adjust back navigation and contour drill comment to match new Lines drill

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6eb9a2e308325a9ffb4f7f9c62ede