### PR TITLE
Use yellow color for experimental tag

### DIFF
--- a/style.css
+++ b/style.css
@@ -399,7 +399,7 @@ h2, h1 { margin: 10px 0; }
 }
 
 .experimental-label {
-  background-color: #ff9800;
+  background-color: #ffeb3b;
 }
 
 .category-memorization {


### PR DESCRIPTION
## Summary
- make experimental label yellow to distinguish it from the orange Adept tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ef751e948325ae9ff462468aeb20