### PR TITLE
Show next line immediately in line memory drill

### DIFF
--- a/line_memory.js
+++ b/line_memory.js
@@ -211,6 +211,8 @@ function pointerUp(e) {
   }
   const prevTarget = target;
   target = randomLine();
+  clearCanvas(ctx);
+  drawTarget();
   drawTargetPreview(prevTarget);
   setTimeout(() => {
     clearCanvas(ctx);


### PR DESCRIPTION
## Summary
- Draw the next target line as soon as a user finishes drawing in the line memory drill
- Overlay the previous attempt as a grey preview that fades after a short delay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f4f1286883259944149d85c8f77e