### PR TITLE
Remove thick line drills from selection

### DIFF
--- a/drills_data.js
+++ b/drills_data.js
@@ -166,26 +166,6 @@ export const drills = [
     scoreKey: 'dexterity_contours'
   },
   {
-    name: 'Thick Lines',
-    url: 'dexterity_thick_lines.html',
-    description: 'Trace thick directional strokes to sharpen your freehand accuracy.',
-    category: 'Dexterity',
-    subject: 'Lines',
-    difficulty: 'Expert',
-    scoreKey: 'dexterity_thick_lines',
-    tags: ['Freehand']
-  },
-  {
-    name: 'Thick Contours',
-    url: 'dexterity_thick_contours.html',
-    description: 'Follow bold C and S curves for steadier freehand control.',
-    category: 'Dexterity',
-    subject: 'Lines',
-    difficulty: 'Expert',
-    scoreKey: 'dexterity_thick_contours',
-    tags: ['Freehand']
-  },
-  {
     name: 'Inch Drill',
     url: 'inch_warmup.html',
     description: 'Draw one-inch strokes by feel to warm up your freehand accuracy.',


### PR DESCRIPTION
## Summary
- remove the Thick Lines and Thick Contours drills from the drill data list so they no longer appear on the drills page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da79fd07708325b0009bf3ac956ff5