### PR TITLE
Align memory shape strikes with point drills

### DIFF
--- a/lines.html
+++ b/lines.html
@@ -11,7 +11,6 @@
     <button id="backBtn">← Back</button>
     <h2>Lines</h2>
     <button id="startBtn">Start</button>
-    <p class="timer" id="timer">60.00</p>
     <canvas
       id="gameCanvas"
       width="500"
@@ -25,6 +24,11 @@
       data-preview-delay="600"
       data-tolerance="6"
     ></canvas>
+    <div id="strikes" class="strikes">
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+    </div>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/quadrilaterals.html
+++ b/quadrilaterals.html
@@ -11,7 +11,6 @@
     <button id="backBtn">← Back</button>
     <h2>Quadrilaterals</h2>
     <button id="startBtn">Start</button>
-    <p class="timer" id="timer">60.00</p>
     <canvas
       id="gameCanvas"
       width="500"
@@ -24,7 +23,13 @@
       data-min-segment-length="70"
       data-preview-delay="800"
       data-tolerance="7"
+      data-fill-shape="true"
     ></canvas>
+    <div id="strikes" class="strikes">
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+    </div>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>

--- a/triangles.html
+++ b/triangles.html
@@ -11,7 +11,6 @@
     <button id="backBtn">← Back</button>
     <h2>Triangles</h2>
     <button id="startBtn">Start</button>
-    <p class="timer" id="timer">60.00</p>
     <canvas
       id="gameCanvas"
       width="500"
@@ -24,7 +23,13 @@
       data-min-segment-length="70"
       data-preview-delay="700"
       data-tolerance="7"
+      data-fill-shape="true"
     ></canvas>
+    <div id="strikes" class="strikes">
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+      <input type="checkbox" class="strike" disabled>
+    </div>
     <p class="score" id="result"></p>
   </div>
   <script src="back.js"></script>


### PR DESCRIPTION
## Summary
- replace the strike counter text in the lines, triangles, and quadrilaterals drills with the checkbox indicators used in the point memorization modes
- update the shared memory shape script to drive the checkbox UI, reset strikes on success, and label strikeouts like the point drills

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da7e0836888325af3debbff34c24a2