### PR TITLE
Adjust Three Points drill difficulty to Adept

### DIFF
--- a/drills_data.js
+++ b/drills_data.js
@@ -14,7 +14,7 @@ export const drills = [
     description: 'Memorize three points.',
     category: 'Memorization',
     subject: 'Points',
-    difficulty: 'Beginner',
+    difficulty: 'Adept',
     scoreKey: 'three_points'
   },
   {

--- a/memorization.html
+++ b/memorization.html
@@ -23,10 +23,10 @@
           <p>Memorize two points.</p>
         </div>
       </div>
-      <div class="exercise-item" data-link="three_points.html" data-difficulty="Beginner">
+      <div class="exercise-item" data-link="three_points.html" data-difficulty="Adept">
         <div class="tag-container">
           <span class="category-label category-memorization">Memorization</span>
-          <span class="difficulty-label difficulty-beginner">Beginner</span>
+          <span class="difficulty-label difficulty-adept">Adept</span>
         </div>
         <img class="exercise-gif" alt="" />
         <div class="exercise-info">

--- a/scenarios.js
+++ b/scenarios.js
@@ -44,7 +44,7 @@ export const scenarioData = {
   "Three Points": {
     url: 'three_points.html',
     description: 'Memorize three points.',
-    difficulty: 'Beginner',
+    difficulty: 'Adept',
     subject: 'Points'
   },
   "Four Points": {


### PR DESCRIPTION
## Summary
- reclassify the Three Points drill as Adept in the drills listing data
- update the memorization menu badge to show Adept difficulty for Three Points
- align scenario metadata so Three Points surfaces as an Adept challenge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dac2e4cbe483258ddcc14b0de2bc91