### PR TITLE
Fix snake drill leaderboard trigger and update tags

### DIFF
--- a/drills_data.js
+++ b/drills_data.js
@@ -165,7 +165,7 @@ export const drills = [
     subject: 'Lines',
     difficulty: 'Adept',
     scoreKey: 'snake',
-    tags: ['Adapt', 'Dexterity', 'Experimental']
+    tags: ['Experimental']
   },
   {
     name: 'Contours',

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -144,7 +144,7 @@
 
     document.body.appendChild(overlay);
 
-    const resultEl = document.querySelector('.score');
+    const resultEl = document.querySelector('#result');
     if (resultEl) {
       resultEl.textContent = '';
       resultEl.style.display = 'none';
@@ -162,7 +162,7 @@
   window.leaderboard = { handleScore, updateLeaderboard, showLeaderboard, getHighScore };
 
   document.addEventListener('DOMContentLoaded', () => {
-    const resultEl = document.querySelector('.score');
+    const resultEl = document.querySelector('#result');
     if (!resultEl) return;
     const canvas = document.querySelector('canvas[data-score-key]');
     const key = canvas ? canvas.dataset.scoreKey : 'default';


### PR DESCRIPTION
## Summary
- prevent the leaderboard script from watching the live score element so the snake drill can run normally
- limit the snake drill tags to only the experimental label as requested

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e30250ae4c8325bfaf6ff8757b3361