### PR TITLE
Fix timer expiry for Medium Points

### DIFF
--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -2,7 +2,7 @@ import { getCanvasPos, clearCanvas, playSound, preventDoubleTapZoom } from './sr
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
 import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
-import { createStrikeCounter } from './src/strike-counter.js';
+import { createStrikeCounter, DEFAULT_TIMER_CONFIG } from './src/strike-counter.js';
 
 let canvas, ctx, startBtn, result, strikeContainer;
 let playing = false;
@@ -14,7 +14,7 @@ let stats = null;
 let startTime = 0;
 let strikeCounter = null;
 
-const MAX_STRIKES = 3;
+const TIMER_SETTINGS = { ...DEFAULT_TIMER_CONFIG, initialSeconds: 0, maxSeconds: 90, successDelta: 3, failureDelta: 8 };
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -44,7 +44,10 @@ function startGame() {
   startScoreboard(canvas);
   result.textContent = '';
   startBtn.disabled = true;
-  strikeCounter = createStrikeCounter(strikeContainer, MAX_STRIKES);
+  if (strikeCounter) {
+    strikeCounter.stop();
+  }
+  strikeCounter = createStrikeCounter(strikeContainer, TIMER_SETTINGS, () => endGame('time'));
   targets = [randomTarget(), randomTarget()];
   drawTargets();
   startTime = Date.now();
@@ -53,13 +56,16 @@ function startGame() {
 function endGame(reason = 'complete') {
   if (!playing) return;
   playing = false;
+  if (strikeCounter) {
+    strikeCounter.stop();
+  }
   clearCanvas(ctx);
   const elapsed = Date.now() - startTime;
   const { score: finalScore, accuracyPct, speed } = calculateScore(
     { green: stats.green, red: stats.red },
     elapsed
   );
-  const prefix = reason === 'strikes' ? 'Out of strikes! ' : '';
+  const prefix = reason === 'time' ? "Time's up! " : '';
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
@@ -83,11 +89,11 @@ function pointerDown(e) {
       updateScoreboard('green');
       hit = true;
       setTimeout(() => playSound(audioCtx, 'green'), 0);
-      if (strikeCounter) {
-        strikeCounter.registerSuccess();
-      }
-      targets[i] = randomTarget();
-      drawTargets();
+    if (strikeCounter) {
+      strikeCounter.registerSuccess();
+    }
+    targets[i] = randomTarget();
+    drawTargets();
       break;
     }
   }
@@ -96,7 +102,7 @@ function pointerDown(e) {
     setTimeout(() => playSound(audioCtx, 'red'), 0);
     updateScoreboard('red');
     if (strikeCounter && strikeCounter.registerFailure()) {
-      endGame('strikes');
+      endGame('time');
       return;
     }
   }


### PR DESCRIPTION
### Motivation
- The Medium Points drill was not using the shared timer configuration and therefore the countdown/expiry behavior was inconsistent.
- Timer instances could persist between runs which prevented clean expiration handling.

### Description
- Import `DEFAULT_TIMER_CONFIG` and introduce `TIMER_SETTINGS` for the Medium Points drill to use the shared timer configuration.
- Stop any existing `strikeCounter` before creating a new one and create it with `createStrikeCounter(strikeContainer, TIMER_SETTINGS, () => endGame('time'))` so expiry triggers `endGame('time')`.
- Stop the `strikeCounter` on game end and change the end message prefix to show `"Time's up! "` when the reason is `'time'`.
- Update failure handling to call `endGame('time')` when the timer reports expiration.

### Testing
- No automated tests were run as part of this change.
- Manual inspection: file `dexterity_point_drill.js` was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a766481d88325bc2ef0df2cef0345)