### PR TITLE
Revert timed drills back to three-strikes mode

### DIFF
--- a/dexterity_contours.js
+++ b/dexterity_contours.js
@@ -2,7 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
 import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
-import { createStrikeCounter, DEFAULT_TIMER_CONFIG } from './src/strike-counter.js';
+import { createStrikeCounter } from './src/strike-counter.js';
 
 let canvas, ctx, startBtn, result, strikeContainer;
 let playing = false;
@@ -30,7 +30,7 @@ const MIN_CURVE_LEN = 200;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
-const TIMER_SETTINGS = { ...DEFAULT_TIMER_CONFIG, initialSeconds: 0, maxSeconds: 120, failureDelta: 8, successDelta: 3 };
+const MAX_STRIKES = 3;
 
 function cubicBezier(p0, p1, p2, p3, t) {
   const mt = 1 - t;
@@ -125,10 +125,7 @@ function startGame() {
   startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
-  strikeCounter = createStrikeCounter(strikeContainer, TIMER_SETTINGS, () => endGame('time'));
+  strikeCounter = createStrikeCounter(strikeContainer, MAX_STRIKES);
   targets = [randomCurve()];
   drawTargets();
 }
@@ -136,16 +133,13 @@ function startGame() {
 function endGame(reason = 'complete') {
   if (!playing) return;
   playing = false;
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
   clearCanvas(ctx);
   const elapsed = Date.now() - startTime;
   const { score: finalScore, accuracyPct, speed } = calculateScore(
     { green: stats.green, red: stats.red },
     elapsed
   );
-  const prefix = reason === 'time' ? "Time's up! " : '';
+  const prefix = reason === 'strikes' ? 'Out of strikes! ' : '';
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
@@ -282,7 +276,7 @@ function pointerUp(e) {
       stats.red += 1;
       updateScoreboard('red');
       if (strikeCounter && strikeCounter.registerFailure()) {
-        endGame('time');
+        endGame('strikes');
       }
     }
   }

--- a/dexterity_lines.js
+++ b/dexterity_lines.js
@@ -2,7 +2,7 @@ import { getCanvasPos, clearCanvas, playSound } from './src/utils.js';
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
 import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
-import { createStrikeCounter, DEFAULT_TIMER_CONFIG } from './src/strike-counter.js';
+import { createStrikeCounter } from './src/strike-counter.js';
 
 let canvas, ctx, startBtn, result, strikeContainer;
 let playing = false;
@@ -26,7 +26,7 @@ const LINE_WIDTH = 2;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 
-const TIMER_SETTINGS = { ...DEFAULT_TIMER_CONFIG, initialSeconds: 0, maxSeconds: 120, failureDelta: 8, successDelta: 3 };
+const MAX_STRIKES = 3;
 
 function randomLine() {
   const margin = 20;
@@ -78,10 +78,7 @@ function startGame() {
   startTime = Date.now();
   result.textContent = '';
   startBtn.disabled = true;
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
-  strikeCounter = createStrikeCounter(strikeContainer, TIMER_SETTINGS, () => endGame('time'));
+  strikeCounter = createStrikeCounter(strikeContainer, MAX_STRIKES);
   targets = [randomLine()];
   drawTargets();
 }
@@ -89,16 +86,13 @@ function startGame() {
 function endGame(reason = 'complete') {
   if (!playing) return;
   playing = false;
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
   clearCanvas(ctx);
   const elapsed = Date.now() - startTime;
   const { score: finalScore, accuracyPct, speed } = calculateScore(
     { green: stats.green, red: stats.red },
     elapsed
   );
-  const prefix = reason === 'time' ? "Time's up! " : '';
+  const prefix = reason === 'strikes' ? 'Out of strikes! ' : '';
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
@@ -214,7 +208,7 @@ function pointerUp(e) {
       stats.red += 1;
       updateScoreboard('red');
       if (strikeCounter && strikeCounter.registerFailure()) {
-        endGame('time');
+        endGame('strikes');
       }
     }
   }

--- a/dexterity_point_drill.js
+++ b/dexterity_point_drill.js
@@ -2,7 +2,7 @@ import { getCanvasPos, clearCanvas, playSound, preventDoubleTapZoom } from './sr
 import { overlayStartButton, hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
 import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
-import { createStrikeCounter, DEFAULT_TIMER_CONFIG } from './src/strike-counter.js';
+import { createStrikeCounter } from './src/strike-counter.js';
 
 let canvas, ctx, startBtn, result, strikeContainer;
 let playing = false;
@@ -14,9 +14,9 @@ let stats = null;
 let startTime = 0;
 let strikeCounter = null;
 
-const TIMER_SETTINGS = { ...DEFAULT_TIMER_CONFIG, initialSeconds: 0, maxSeconds: 90, successDelta: 3, failureDelta: 8 };
-
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+const MAX_STRIKES = 3;
 
 function randomTarget() {
   const margin = 20;
@@ -44,10 +44,7 @@ function startGame() {
   startScoreboard(canvas);
   result.textContent = '';
   startBtn.disabled = true;
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
-  strikeCounter = createStrikeCounter(strikeContainer, TIMER_SETTINGS, () => endGame('time'));
+  strikeCounter = createStrikeCounter(strikeContainer, MAX_STRIKES);
   targets = [randomTarget(), randomTarget()];
   drawTargets();
   startTime = Date.now();
@@ -56,16 +53,13 @@ function startGame() {
 function endGame(reason = 'complete') {
   if (!playing) return;
   playing = false;
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
   clearCanvas(ctx);
   const elapsed = Date.now() - startTime;
   const { score: finalScore, accuracyPct, speed } = calculateScore(
     { green: stats.green, red: stats.red },
     elapsed
   );
-  const prefix = reason === 'time' ? "Time's up! " : '';
+  const prefix = reason === 'strikes' ? 'Out of strikes! ' : '';
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, finalScore);
     const high = window.leaderboard.getHighScore(scoreKey);
@@ -102,7 +96,7 @@ function pointerDown(e) {
     setTimeout(() => playSound(audioCtx, 'red'), 0);
     updateScoreboard('red');
     if (strikeCounter && strikeCounter.registerFailure()) {
-      endGame('time');
+      endGame('strikes');
       return;
     }
   }

--- a/point_drill_025.js
+++ b/point_drill_025.js
@@ -2,7 +2,7 @@ import { getCanvasPos, clearCanvas, playSound, preventDoubleTapZoom } from './sr
 import { hideStartButton } from './src/start-button.js';
 import { calculateScore } from './src/scoring.js';
 import { startScoreboard, updateScoreboard } from './src/scoreboard.js';
-import { createStrikeCounter, DEFAULT_TIMER_CONFIG } from './src/strike-counter.js';
+import { createStrikeCounter } from './src/strike-counter.js';
 
 let canvas, ctx, feedbackCanvas, feedbackCtx, startBtn, result, strikeContainer;
 
@@ -18,8 +18,7 @@ let strikeCounter = null;
 
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const RESULT_DISPLAY_TIME = 300;
-const TIMER_SETTINGS = { ...DEFAULT_TIMER_CONFIG, initialSeconds: 0, maxSeconds: 90, successDelta: 3, failureDelta: 8 };
-
+const MAX_STRIKES = 3;
 function drawTarget() {
   const margin = 20;
   target = {
@@ -84,7 +83,7 @@ function pointerDown(e) {
   }
   showPoints(pos, prevTarget, grade);
   if (exhausted) {
-    setTimeout(() => endGame('time'), RESULT_DISPLAY_TIME);
+    setTimeout(() => endGame('strikes'), RESULT_DISPLAY_TIME);
   }
 }
 
@@ -98,10 +97,7 @@ function startGame() {
   result.textContent = '';
   startBtn.disabled = true;
   startTime = Date.now();
-  if (strikeCounter) {
-    strikeCounter.stop();
-  }
-  strikeCounter = createStrikeCounter(strikeContainer, TIMER_SETTINGS, () => endGame('time'));
+  strikeCounter = createStrikeCounter(strikeContainer, MAX_STRIKES);
   drawTarget();
 }
 
@@ -119,7 +115,7 @@ function endGame(reason = 'complete') {
   const avg = stats.totalPoints ? stats.totalErr / stats.totalPoints : 0;
   const elapsed = Date.now() - startTime;
   const { score, accuracyPct, speed } = calculateScore(stats, elapsed);
-  const prefix = reason === 'time' ? "Time's up! " : '';
+  const prefix = reason === 'strikes' ? 'Out of strikes! ' : '';
   if (window.leaderboard) {
     window.leaderboard.updateLeaderboard(scoreKey, score);
     const high = window.leaderboard.getHighScore(scoreKey);


### PR DESCRIPTION
### Motivation
- Switch the affected drills from timer-driven behavior back to a simple three-strikes mechanic because the timer-based configuration was too complicated.

### Description
- Removed use of `DEFAULT_TIMER_CONFIG` / `TIMER_SETTINGS` and stopped initializing the timer-based strike counter in `dexterity_lines.js`, `dexterity_contours.js`, `dexterity_point_drill.js`, and `point_drill_025.js`.
- Added a fixed `MAX_STRIKES = 3` constant and initialize the strike counter with `createStrikeCounter(strikeContainer, MAX_STRIKES)` in those files.
- Updated loss handling to end on strike exhaustion by calling `endGame('strikes')` and changed the end-game prefix from the timer message to `Out of strikes!` where applicable.
- Removed redundant timer-stop logic that was tied to the previous timer configuration so the drills use consistent strike-only behavior.

### Testing
- Ran the project test suite with `npm test`, and all test suites passed (`8` suites, `26` tests).
- No browser/UI screenshot tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c939462d64832588a1a20e840d15fb)