### PR TITLE
Add Canvas Tool button to main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
       <button id="tutorialBtn">Tutorial</button>
       <button id="scenariosBtn">Scenarios</button>
       <button id="aboutBtn">About</button>
+      <button id="canvasBtn">Canvas Tool</button>
       <button id="resetScoresBtn">Reset High Scores</button>
     </div>
   </div>

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('aboutBtn')?.addEventListener('click', () => {
     window.location.href = 'about.html';
   });
+  document.getElementById('canvasBtn')?.addEventListener('click', () => {
+    window.location.href = 'drawing_canvas.html';
+  });
   document.querySelectorAll('.drill-link').forEach(button => {
     button.addEventListener('click', () => {
       const subject = button.dataset.subject || 'Points';


### PR DESCRIPTION
### Motivation
- Expose the new drawing canvas tool directly from the application's main menu so it's easy to open and test.

### Description
- Add a `Canvas Tool` button to the main menu in `index.html` and wire `document.getElementById('canvasBtn')` in `index.js` to navigate to `drawing_canvas.html`.

### Testing
- Ran unit tests with `npm test -- --runInBand`, and all test suites passed (8 passed, 26 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c943c818b48325923e87ff2a010417)