### PR TITLE
Consolidate exercises into Dexterity, Observation, and Memory tabs

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -9,36 +9,24 @@
 <body>
   <div class="menu-screen">
     <button id="backBtn">← Back</button>
-    <div class="drill-category-menu">
+    <div class="drill-category-menu" role="tablist" aria-label="Exercise categories">
       <div class="drill-category-item">
-        <button class="drill-category-button" data-subject="Points">Points</button>
-        <p>Practice locating and remembering precise points.</p>
+        <button class="drill-category-button" data-category="Dexterity" role="tab">Dexterity</button>
+        <p>Practice hand control, pointer accuracy, and smooth tracing.</p>
       </div>
       <div class="drill-category-item">
-        <button class="drill-category-button" data-subject="Lines">Lines</button>
-        <p>Improve your flow with tracing and line control exercises.</p>
+        <button class="drill-category-button" data-category="Observation" role="tab">Observation</button>
+        <p>Study what is visible and judge angles, colors, values, and reference shapes.</p>
       </div>
       <div class="drill-category-item">
-        <button class="drill-category-button" data-subject="Shapes">Shapes</button>
-        <p>Challenge your memory with angles, triangles, and complex shapes.</p>
-      </div>
-      <div class="drill-category-item">
-        <button class="drill-category-button" data-subject="Forms">Forms</button>
-        <p>Practice anatomy-focused SVG memory drills for each body region.</p>
-      </div>
-      <div class="drill-category-item">
-        <button class="drill-category-button" data-subject="Colors">Colors</button>
-        <p>Develop stronger color recall with hue and palette exercises.</p>
+        <button class="drill-category-button" data-category="Memory" role="tab">Memory</button>
+        <p>Memorize brief previews, then recreate points, lines, forms, colors, and shapes.</p>
       </div>
     </div>
     <div class="exercise-columns">
-      <div class="exercise-group">
-        <h3>Dexterity</h3>
-        <div id="dexterityList" class="exercise-list"></div>
-      </div>
-      <div class="exercise-group">
-        <h3>Memory</h3>
-        <div id="memoryList" class="exercise-list"></div>
+      <div class="exercise-group active-category-group">
+        <h3 id="activeCategoryTitle">Dexterity</h3>
+        <div id="exerciseList" class="exercise-list"></div>
       </div>
     </div>
   </div>

--- a/drills.js
+++ b/drills.js
@@ -12,6 +12,26 @@ const difficultyClassMap = {
   Expert: 'difficulty-expert'
 };
 
+const categoryClassMap = {
+  Dexterity: 'category-dexterity',
+  Observation: 'category-observation',
+  Memory: 'category-memory'
+};
+
+const displayCategoryMap = {
+  Memorization: 'Memory'
+};
+
+const categoryDescriptions = {
+  Dexterity: 'Motor-control exercises for steadier hands, cleaner lines, and more accurate taps.',
+  Observation: 'Direct-looking exercises for judging visible angles, color, value, and reference shapes.',
+  Memory: 'Recall exercises that hide the prompt before you recreate the target from memory.'
+};
+
+function getDisplayCategory(category) {
+  return displayCategoryMap[category] || category || 'Dexterity';
+}
+
 function createLabelSpan(baseClass, text, extraClass) {
   const span = document.createElement('span');
   span.className = [baseClass, extraClass].filter(Boolean).join(' ');
@@ -21,8 +41,10 @@ function createLabelSpan(baseClass, text, extraClass) {
 
 function createExerciseItem(drill) {
   const item = document.createElement('div');
+  const displayCategory = getDisplayCategory(drill.category);
   item.className = 'exercise-item';
   item.dataset.link = drill.url;
+  item.dataset.category = displayCategory;
   if (drill.subject) {
     item.dataset.subject = drill.subject;
   }
@@ -35,6 +57,9 @@ function createExerciseItem(drill) {
 
   const tagContainer = document.createElement('div');
   tagContainer.className = 'tag-container';
+  tagContainer.appendChild(
+    createLabelSpan('category-label', displayCategory, categoryClassMap[displayCategory])
+  );
   if (drill.difficulty) {
     tagContainer.appendChild(
       createLabelSpan('difficulty-label', drill.difficulty, difficultyClassMap[drill.difficulty])
@@ -69,18 +94,21 @@ const difficultyOrder = {
   Expert: 2
 };
 
-function renderExerciseLists() {
-  const dexterityList = document.getElementById('dexterityList');
-  const memoryList = document.getElementById('memoryList');
+function renderExerciseList() {
+  const exerciseList = document.getElementById('exerciseList');
 
-  if (!dexterityList || !memoryList) {
+  if (!exerciseList) {
     return Array.from(document.querySelectorAll('.exercise-item'));
   }
 
-  dexterityList.innerHTML = '';
-  memoryList.innerHTML = '';
+  exerciseList.innerHTML = '';
 
   const sortedDrills = [...drills].sort((a, b) => {
+    const categoryA = getDisplayCategory(a.category);
+    const categoryB = getDisplayCategory(b.category);
+    if (categoryA !== categoryB) {
+      return categoryA.localeCompare(categoryB);
+    }
     const diffA = difficultyOrder[a.difficulty] ?? Number.POSITIVE_INFINITY;
     const diffB = difficultyOrder[b.difficulty] ?? Number.POSITIVE_INFINITY;
     if (diffA !== diffB) {
@@ -89,50 +117,32 @@ function renderExerciseLists() {
     return a.name.localeCompare(b.name);
   });
 
-  return sortedDrills
-    .map(drill => {
-      const item = createExerciseItem(drill);
-      const targetList =
-        drill.category === 'Dexterity'
-          ? dexterityList
-          : drill.category === 'Memorization'
-          ? memoryList
-          : null;
-
-      if (!targetList) {
-        return null;
-      }
-
-      targetList.appendChild(item);
-      return item;
-    })
-    .filter(Boolean);
+  return sortedDrills.map(drill => {
+    const item = createExerciseItem(drill);
+    exerciseList.appendChild(item);
+    return item;
+  });
 }
 
 function init() {
-  const items = renderExerciseLists();
+  const items = renderExerciseList();
+  const buttons = Array.from(document.querySelectorAll('.drill-category-button'));
+  const title = document.getElementById('activeCategoryTitle');
 
-  const subjectGroups = {
-    Points: ['Points'],
-    Lines: ['Lines'],
-    Shapes: ['Shapes', 'Angles', 'Ellipses', 'Ellipse'],
-    Forms: ['Forms'],
-    Colors: ['Colors', 'Color']
+  const getCategoryKey = category => {
+    const normalized = getDisplayCategory(category);
+    return categoryDescriptions[normalized] ? normalized : 'Dexterity';
   };
 
-  const legacySubjectMap = {
-    Values: 'Colors'
-  };
-
-  const getSubjectKey = subject => subjectGroups[subject] ? subject : legacySubjectMap[subject] || 'Points';
-
-  const selectSubject = subject => {
-    const subjectKey = getSubjectKey(subject);
-    const allowedSubjects = subjectGroups[subjectKey] || subjectGroups.Points;
+  const selectCategory = category => {
+    const categoryKey = getCategoryKey(category);
     items.forEach(item => {
-      const itemSubject = item.dataset.subject;
-      item.style.display = allowedSubjects.includes(itemSubject) ? '' : 'none';
+      item.style.display = item.dataset.category === categoryKey ? '' : 'none';
     });
+    if (title) {
+      title.textContent = categoryKey;
+      title.dataset.description = categoryDescriptions[categoryKey];
+    }
   };
 
   items.forEach(item => {
@@ -150,32 +160,32 @@ function init() {
     });
   });
 
-  const buttons = Array.from(document.querySelectorAll('.drill-category-button'));
   const params = new URLSearchParams(window.location.search);
-  const defaultSubject = params.get('subject');
+  const defaultCategory = params.get('category') || params.get('subject');
+  const normalizedCategory = getCategoryKey(defaultCategory || 'Dexterity');
 
-  const normalizedSubject = getSubjectKey(defaultSubject || 'Points');
-
-  const setActiveButton = subject => {
-    const subjectKey = getSubjectKey(subject);
+  const setActiveButton = category => {
+    const categoryKey = getCategoryKey(category);
     buttons.forEach(button => {
-      const isActive = button.dataset.subject === subjectKey;
+      const isActive = button.dataset.category === categoryKey;
       button.classList.toggle('active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
     });
-    selectSubject(subjectKey);
+    selectCategory(categoryKey);
   };
 
   buttons.forEach(button => {
     button.addEventListener('click', () => {
-      const subject = button.dataset.subject || 'Points';
+      const category = button.dataset.category || 'Dexterity';
       const url = new URL(window.location.href);
-      url.searchParams.set('subject', subject);
+      url.searchParams.delete('subject');
+      url.searchParams.set('category', category);
       window.history.replaceState({}, '', url.toString());
-      setActiveButton(subject);
+      setActiveButton(category);
     });
   });
 
-  setActiveButton(normalizedSubject);
+  setActiveButton(normalizedCategory);
 }
 
 if (document.readyState === 'loading') {

--- a/drills_data.js
+++ b/drills_data.js
@@ -3,7 +3,7 @@ export const drills = [
     name: 'Two Points',
     url: 'two_points.html',
     description: 'Memorize two points.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Points',
     difficulty: 'Beginner',
     scoreKey: 'two_points'
@@ -12,7 +12,7 @@ export const drills = [
     name: 'Three Points',
     url: 'three_points.html',
     description: 'Memorize three points.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Points',
     difficulty: 'Adept',
     scoreKey: 'three_points'
@@ -21,7 +21,7 @@ export const drills = [
     name: 'Four Points',
     url: 'four_points.html',
     description: 'Memorize four points.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Points',
     difficulty: 'Adept',
     scoreKey: 'four_points'
@@ -30,7 +30,7 @@ export const drills = [
     name: 'Lines',
     url: 'lines.html',
     description: 'Memorize a line segment and recreate it freehand.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Lines',
     difficulty: 'Beginner',
     scoreKey: 'memory_lines',
@@ -40,7 +40,7 @@ export const drills = [
     name: 'Contours',
     url: 'memory_contours.html',
     description: 'Memorize flowing contour curves and redraw them from memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Lines',
     difficulty: 'Expert',
     scoreKey: 'memory_contours',
@@ -50,7 +50,7 @@ export const drills = [
     name: 'Triangles',
     url: 'triangles.html',
     description: 'Memorize a triangle outline and redraw it from memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Shapes',
     difficulty: 'Adept',
     scoreKey: 'memory_triangles',
@@ -60,7 +60,7 @@ export const drills = [
     name: 'Quadrilaterals',
     url: 'quadrilaterals.html',
     description: 'Memorize a quadrilateral outline and redraw it from memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Shapes',
     difficulty: 'Expert',
     scoreKey: 'memory_quadrilaterals',
@@ -70,7 +70,7 @@ export const drills = [
     name: 'Ellipses',
     url: 'ellipses.html',
     description: 'Memorize an ellipse and redraw it from memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Shapes',
     difficulty: 'Expert',
     scoreKey: 'memory_ellipses',
@@ -80,7 +80,7 @@ export const drills = [
     name: 'Complex Shapes',
     url: 'complex_shapes.html',
     description: 'Memorize mixed curved and straight shapes.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Shapes',
     difficulty: 'Expert',
     scoreKey: 'complex_shapes'
@@ -89,7 +89,7 @@ export const drills = [
     name: 'Angles (5° increments)',
     url: 'angles.html',
     description: 'Guess randomly oriented angles in 5° steps.',
-    category: 'Memorization',
+    category: 'Observation',
     subject: 'Angles',
     difficulty: 'Expert',
     scoreKey: 'angles_5'
@@ -98,7 +98,7 @@ export const drills = [
     name: 'Angles (10° increments)',
     url: 'angles.html?step=10',
     description: 'Guess randomly oriented angles in 10° steps.',
-    category: 'Memorization',
+    category: 'Observation',
     subject: 'Angles',
     difficulty: 'Beginner',
     scoreKey: 'angles_10'
@@ -107,7 +107,7 @@ export const drills = [
     name: 'Point Drill 0.5 sec Look',
     url: 'point_drill_05.html',
     description: 'Memorize a point after a 0.5 second preview and tap its location.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Points',
     difficulty: 'Beginner',
     scoreKey: 'point_drill_05'
@@ -116,7 +116,7 @@ export const drills = [
     name: 'Point Drill 0.25 sec Look',
     url: 'point_drill_025.html',
     description: 'Memorize a point after a 0.25 second preview and tap its location.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Points',
     difficulty: 'Adept',
     scoreKey: 'point_drill_025'
@@ -125,7 +125,7 @@ export const drills = [
     name: 'Point Drill 0.1 sec Look',
     url: 'point_drill_01.html',
     description: 'Memorize a point after a 0.1 second preview and tap its location.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Points',
     difficulty: 'Expert',
     scoreKey: 'point_drill_01'
@@ -134,7 +134,7 @@ export const drills = [
     name: 'Memory Values',
     url: 'memory_values.html',
     description: 'Memorize a grayscale square and match its value with the slider.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Color',
     difficulty: 'Beginner',
     scoreKey: 'memory_values'
@@ -143,7 +143,7 @@ export const drills = [
     name: 'Memory Colors',
     url: 'memory_color.html',
     description: 'Memorize a color square and match its value, hue, and chroma.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Color',
     difficulty: 'Adept',
     scoreKey: 'memory_color'
@@ -152,7 +152,7 @@ export const drills = [
     name: 'Eyes (SVG Memory)',
     url: 'svg_shape_drill.html?category=eyes',
     description: 'Memorize and trace eye contours pulled from SVG plates.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_eyes'
@@ -161,7 +161,7 @@ export const drills = [
     name: 'Ears (SVG Memory)',
     url: 'svg_shape_drill.html?category=ears',
     description: 'Practice ear outlines for structural recall.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_ears'
@@ -170,7 +170,7 @@ export const drills = [
     name: 'Noses (SVG Memory)',
     url: 'svg_shape_drill.html?category=noses',
     description: 'Drill nose silhouettes to strengthen form memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_noses'
@@ -179,7 +179,7 @@ export const drills = [
     name: 'Lips (SVG Memory)',
     url: 'svg_shape_drill.html?category=lips',
     description: 'Trace lip shapes to commit proportion patterns to memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_lips'
@@ -188,7 +188,7 @@ export const drills = [
     name: 'Heads (SVG Memory)',
     url: 'svg_shape_drill.html?category=heads',
     description: 'Study head masses and block-ins with SVG contours.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_heads'
@@ -197,7 +197,7 @@ export const drills = [
     name: 'Torsos (SVG Memory)',
     url: 'svg_shape_drill.html?category=torsos',
     description: 'Reinforce torso construction through repeat tracing.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_torsos'
@@ -206,7 +206,7 @@ export const drills = [
     name: 'Arms (SVG Memory)',
     url: 'svg_shape_drill.html?category=arms',
     description: 'Focus on arm rhythms and landmarks via SVG outlines.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_arms'
@@ -215,7 +215,7 @@ export const drills = [
     name: 'Legs (SVG Memory)',
     url: 'svg_shape_drill.html?category=legs',
     description: 'Trace leg proportions to improve structural recall.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_legs'
@@ -224,7 +224,7 @@ export const drills = [
     name: 'Hands (SVG Memory)',
     url: 'svg_shape_drill.html?category=hands',
     description: 'Practice hand silhouettes for gesture and proportion memory.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_hands'
@@ -233,10 +233,19 @@ export const drills = [
     name: 'Feet (SVG Memory)',
     url: 'svg_shape_drill.html?category=feet',
     description: 'Drill foot outlines to memorize structure and balance.',
-    category: 'Memorization',
+    category: 'Memory',
     subject: 'Forms',
     difficulty: 'Adept',
     scoreKey: 'forms_feet'
+  },
+  {
+    name: 'Observation Drawing',
+    url: 'observation.html',
+    description: 'Copy a visible reference beside your drawing canvas and compare the two directly.',
+    category: 'Observation',
+    subject: 'Shapes',
+    difficulty: 'Beginner',
+    scoreKey: 'observation'
   },
   {
     name: 'Large Points',
@@ -279,7 +288,7 @@ export const drills = [
     name: 'Value Match',
     url: 'dexterity_values.html',
     description: 'Rapidly match grayscale swatches with the Munsell value slider.',
-    category: 'Dexterity',
+    category: 'Observation',
     subject: 'Values',
     difficulty: 'Beginner',
     scoreKey: 'dexterity_values'
@@ -288,7 +297,7 @@ export const drills = [
     name: 'Color Match',
     url: 'dexterity_color.html',
     description: 'Quickly dial in hue, value, and chroma to hit target colors.',
-    category: 'Dexterity',
+    category: 'Observation',
     subject: 'Color',
     difficulty: 'Adept',
     scoreKey: 'dexterity_color'
@@ -297,7 +306,7 @@ export const drills = [
     name: 'SVG Shape Drill',
     url: 'svg_shape_drill.html',
     description: 'Trace SVG outlines for anatomy studies and mastercopy plates.',
-    category: 'Dexterity',
+    category: 'Observation',
     subject: 'Shapes',
     difficulty: 'Adept',
     scoreKey: 'svg_shape_drill',

--- a/index.html
+++ b/index.html
@@ -11,26 +11,18 @@
   <div id="menuScreen" class="screen visible menu-screen">
     <h1>Artist Trainer</h1>
     <p>by Sawyer Wall</p>
-    <div class="menu-grid">
+    <div class="menu-grid menu-grid-three">
       <div class="menu-card">
-        <button class="drill-link" data-subject="Points">Points</button>
-        <p>Sharpen your precision by memorizing and tapping points.</p>
+        <button class="drill-link" data-category="Dexterity">Dexterity</button>
+        <p>Build hand control with tapping, tracing, line, curve, and shape-following drills.</p>
       </div>
       <div class="menu-card">
-        <button class="drill-link" data-subject="Lines">Lines</button>
-        <p>Build confident strokes with guided line and tracing drills.</p>
+        <button class="drill-link" data-category="Observation">Observation</button>
+        <p>Train direct visual judgment with angle, value, color, and reference-copy exercises.</p>
       </div>
       <div class="menu-card">
-        <button class="drill-link" data-subject="Shapes">Shapes</button>
-        <p>Train your visual memory with triangles, angles, and complex forms.</p>
-      </div>
-      <div class="menu-card">
-        <button class="drill-link" data-subject="Forms">Forms</button>
-        <p>Study anatomical features with SVG-based tracing and memory drills.</p>
-      </div>
-      <div class="menu-card">
-        <button class="drill-link" data-subject="Colors">Colors</button>
-        <p>Sharpen color recall and recognition through targeted exercises.</p>
+        <button class="drill-link" data-category="Memory">Memory</button>
+        <p>Strengthen recall by briefly studying points, contours, forms, colors, and shapes.</p>
       </div>
     </div>
     <div class="menu-actions">

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   document.querySelectorAll('.drill-link').forEach(button => {
     button.addEventListener('click', () => {
-      const subject = button.dataset.subject || 'Points';
-      const query = new URLSearchParams({ subject }).toString();
+      const category = button.dataset.category || 'Dexterity';
+      const query = new URLSearchParams({ category }).toString();
       window.location.href = `drills.html?${query}`;
     });
   });

--- a/style.css
+++ b/style.css
@@ -48,6 +48,10 @@ select {
   max-width: 720px;
 }
 
+.menu-grid-three {
+  max-width: 900px;
+}
+
 .menu-card {
   flex: 1 1 200px;
   max-width: 220px;
@@ -644,6 +648,16 @@ h2, h1 { margin: 10px 0; }
   color: #333;
 }
 
+.exercise-group > h3::after {
+  content: attr(data-description);
+  display: block;
+  max-width: 560px;
+  margin-top: 6px;
+  font-size: 15px;
+  font-weight: 400;
+  color: #555;
+}
+
 .exercise-list {
   display: flex;
   flex-direction: column;
@@ -740,12 +754,17 @@ h2, h1 { margin: 10px 0; }
   background-color: #607d8b;
 }
 
-.category-memorization {
+.category-memorization,
+.category-memory {
   background-color: #82B3B3;
 }
 
 .category-dexterity {
   background-color: #B382B3;
+}
+
+.category-observation {
+  background-color: #5f8dd3;
 }
 
 .difficulty-beginner {


### PR DESCRIPTION
### Motivation
- Simplify the main menu and drills navigation by grouping all exercises into three high-level categories: `Dexterity`, `Observation`, and `Memory`, and place each existing drill contextually into the appropriate tab.

### Description
- Replaced the menu subject cards in `index.html` with three category cards and updated main-menu navigation in `index.js` to open `drills.html` with a `category` query parameter instead of the old `subject` parameter.
- Reworked `drills.html` to use three accessible category tabs and a single, filtered exercise list instead of separate Dexterity/Memory columns.
- Rewrote `drills.js` to normalize categories (mapping old `Memorization` to `Memory`), add category labels and descriptions, render a single list of exercises, and filter items by the new `Dexterity` / `Observation` / `Memory` categories while preserving difficulty ordering and score display.
- Updated `drills_data.js` to reclassify drills into the three categories (moved angle/value/color/SVG copy exercises into `Observation`, recall drills into `Memory`, and motor-control drills into `Dexterity`) and added an `Observation Drawing` entry.
- Adjusted styles in `style.css` for the wider three-card menu, category label colors, and showing category descriptions under the active group title.

### Testing
- Ran syntax checks with `node --check drills.js && node --check drills_data.js && node --check index.js`, which completed successfully.
- Ran the full test suite with `npm test -- --runInBand`, and all test suites passed (`8 passed, 8 total`).
- Attempted a visual verification screenshot via Playwright but the environment blocked the browser download (Playwright CDN returned a 403), so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53dc5974c083258be38baa5f41e9fd)